### PR TITLE
Make stack switcher homogeneous

### DIFF
--- a/src/Keyboard.vala
+++ b/src/Keyboard.vala
@@ -18,17 +18,18 @@ public class Pantheon.Keyboard.Plug : Switchboard.Plug {
 
     public override Gtk.Widget get_widget () {
         if (grid == null) {
-            grid = new Gtk.Grid ();
-            grid.margin = 12;
             stack = new Gtk.Stack ();
-            var stack_switcher = new Gtk.StackSwitcher ();
-            stack_switcher.set_stack (stack);
-            stack_switcher.halign = Gtk.Align.CENTER;
-
             stack.add_titled (new Keyboard.LayoutPage.Page (), "layout", _("Layout"));
             stack.add_titled (new Keyboard.Shortcuts.Page (), "shortcuts", _("Shortcuts"));
             stack.add_titled (new Keyboard.Behaviour.Page (), "behavior", _("Behavior"));
 
+            var stack_switcher = new Gtk.StackSwitcher ();
+            stack_switcher.halign = Gtk.Align.CENTER;
+            stack_switcher.homogeneous = true;
+            stack_switcher.stack = stack;
+
+            grid = new Gtk.Grid ();
+            grid.margin = 12;
             grid.attach (stack_switcher, 0, 0, 1, 1);
             grid.attach (stack, 0, 1, 1, 1);
         }


### PR DESCRIPTION
Stack switcher buttons are no longer homogeneous width by default in gtk >= 3.20

Do some organization while we're here