### PR TITLE
AbstractPage.vala: remove unnecessary properties

### DIFF
--- a/src/Keyboard.vala
+++ b/src/Keyboard.vala
@@ -19,17 +19,18 @@ public class Pantheon.Keyboard.Plug : Switchboard.Plug {
     public override Gtk.Widget get_widget () {
         if (grid == null) {
             stack = new Gtk.Stack ();
+            stack.margin = 12;
             stack.add_titled (new Keyboard.LayoutPage.Page (), "layout", _("Layout"));
             stack.add_titled (new Keyboard.Shortcuts.Page (), "shortcuts", _("Shortcuts"));
             stack.add_titled (new Keyboard.Behaviour.Page (), "behavior", _("Behavior"));
 
             var stack_switcher = new Gtk.StackSwitcher ();
+            stack_switcher.margin = 12;
             stack_switcher.halign = Gtk.Align.CENTER;
             stack_switcher.homogeneous = true;
             stack_switcher.stack = stack;
 
             grid = new Gtk.Grid ();
-            grid.margin = 12;
             grid.attach (stack_switcher, 0, 0, 1, 1);
             grid.attach (stack, 0, 1, 1, 1);
         }

--- a/src/Views/AbstractPage.vala
+++ b/src/Views/AbstractPage.vala
@@ -17,16 +17,11 @@
 * Boston, MA 02110-1301 USA
 */
 
-// a common class for all pages
 public abstract class Pantheon.Keyboard.AbstractPage : Gtk.Grid {
     public AbstractPage () {
         Object (
-            column_homogeneous: false,
-            row_homogeneous: false,
             column_spacing: 12,
-            row_spacing: 12,
-            margin_bottom: 12,
-            margin_top: 12
+            row_spacing: 12
         );
     }
 


### PR DESCRIPTION
* Row and column homogeneous are false by default
* Set margins on the stack (and stack switcher) instead of on each page inside the stack