### PR TITLE
Layout.vala: Replace switch creation methods with class

### DIFF
--- a/src/Views/Layout.vala
+++ b/src/Views/Layout.vala
@@ -281,7 +281,7 @@ namespace Pantheon.Keyboard.LayoutPage {
                 halign = Gtk.Align.START;
                 valign = Gtk.Align.CENTER;
 
-                var modifier = new Xkb_modifier (""+xkb_command);
+                var modifier = new Xkb_modifier ("" + xkb_command);
                 modifier.append_xkb_option ("", "option off");
                 modifier.append_xkb_option (xkb_command, "option on");
 


### PR DESCRIPTION
* Replaces two switch creation methods with a single class
* Since all switches are the same length, we only need to add one of them to the size group for alignment

This should probably be tested by Korean/Japanese layout users to make certain that these switches still work as expected