### PR TITLE
Use fewer symbols to represent keys

### DIFF
--- a/src/Shortcuts/Shortcut.vala
+++ b/src/Shortcuts/Shortcut.vala
@@ -42,28 +42,48 @@ namespace Pantheon.Keyboard.Shortcuts
 				
 			string tmp = "";
 			
-			if ((modifiers & Gdk.ModifierType.SHIFT_MASK) > 0)
-			    tmp += "⇧" + SEPARATOR;
-			if ((modifiers & Gdk.ModifierType.SUPER_MASK) > 0)
-			    tmp += "⌘" + SEPARATOR;
-			if ((modifiers & Gdk.ModifierType.CONTROL_MASK) > 0)
-			    tmp += _("Ctrl") + SEPARATOR;
-			if ((modifiers & Gdk.ModifierType.MOD1_MASK) > 0)
-			    tmp += "⎇" + SEPARATOR;
-			if ((modifiers & Gdk.ModifierType.MOD2_MASK) > 0)
-			    tmp += "Mod2" + SEPARATOR;
-			if ((modifiers & Gdk.ModifierType.MOD3_MASK) > 0)
-			    tmp += "Mod3" + SEPARATOR;
-			if ((modifiers & Gdk.ModifierType.MOD4_MASK) > 0)
-			    tmp += "Mod4" + SEPARATOR;
+            if ((modifiers & Gdk.ModifierType.SHIFT_MASK) > 0) {
+                tmp += _("Shift") + SEPARATOR;
+            }
+
+            if ((modifiers & Gdk.ModifierType.SUPER_MASK) > 0) {
+                tmp += "⌘" + SEPARATOR;
+            }
+
+            if ((modifiers & Gdk.ModifierType.CONTROL_MASK) > 0) {
+                tmp += _("Ctrl") + SEPARATOR;
+            }
+
+            if ((modifiers & Gdk.ModifierType.MOD1_MASK) > 0) {
+                tmp += _("Alt") + SEPARATOR;
+            }
+
+            if ((modifiers & Gdk.ModifierType.MOD2_MASK) > 0) {
+                tmp += "Mod2" + SEPARATOR;
+            }
+
+            if ((modifiers & Gdk.ModifierType.MOD3_MASK) > 0) {
+                tmp += "Mod3" + SEPARATOR;
+            }
+
+            if ((modifiers & Gdk.ModifierType.MOD4_MASK) > 0) {
+                tmp += "Mod4" + SEPARATOR;
+            }
+
 
             switch (accel_key) {
-            
-                case Gdk.Key.Tab:   tmp += "↹"; break;
-                case Gdk.Key.Up:    tmp += "↑"; break;
-                case Gdk.Key.Down:  tmp += "↓"; break;
-                case Gdk.Key.Left:  tmp += "←"; break;
-                case Gdk.Key.Right: tmp += "→"; break;
+                case Gdk.Key.Up:
+                    tmp += "↑";
+                    break;
+                case Gdk.Key.Down:
+                    tmp += "↓";
+                    break;
+                case Gdk.Key.Left:
+                    tmp += "←";
+                    break;
+                case Gdk.Key.Right:
+                    tmp += "→";
+                    break;
                 default:
                     tmp += Gtk.accelerator_get_label (accel_key, 0);
                     break;


### PR DESCRIPTION
Fixes #4 

Changes the "Shift", "Alt", and "Tab" keys to be spelled out instead of symbols.

Also fixes code style while we're here

## Before:

![screenshot from 2018-02-20 11 34 20](https://user-images.githubusercontent.com/7277719/36445079-0255a38c-1632-11e8-822d-587d936bb390.png)


## After:

![screenshot from 2018-02-20 11 31 23](https://user-images.githubusercontent.com/7277719/36445044-e352a5ac-1631-11e8-9741-26f541af32e6.png)