### PR TITLE
Use plus as a separator

### DIFF
--- a/src/Shortcuts/Shortcut.vala
+++ b/src/Shortcuts/Shortcut.vala
@@ -7,7 +7,7 @@ namespace Pantheon.Keyboard.Shortcuts
 		public Gdk.ModifierType  modifiers;
 		public uint              accel_key;
 		
-		string SEPARATOR = " · ";
+		string SEPARATOR = " + ";
 		
 		// constructors
 		public Shortcut (uint key = 0, Gdk.ModifierType mod = (Gdk.ModifierType) 0)

--- a/src/Shortcuts/Shortcut.vala
+++ b/src/Shortcuts/Shortcut.vala
@@ -6,9 +6,9 @@ namespace Pantheon.Keyboard.Shortcuts
 	{
 		public Gdk.ModifierType  modifiers;
 		public uint              accel_key;
-		
-		string SEPARATOR = " + ";
-		
+
+        string SEPARATOR = " + ";
+
 		// constructors
 		public Shortcut (uint key = 0, Gdk.ModifierType mod = (Gdk.ModifierType) 0)
 		{


### PR DESCRIPTION
Whenever we describe a shortcut in the UI in other places we always use `+` as in `Alt + Tab`, but here we're using `·`. This branch makes it `+`