### PR TITLE
Move launch music to apps section

### DIFF
--- a/src/Shortcuts/List.vala
+++ b/src/Shortcuts/List.vala
@@ -84,6 +84,7 @@ namespace Pantheon.Keyboard.Shortcuts {
             Group launchers_group = {};
             add_action (ref launchers_group, Schema.MEDIA, _("Email"), "email");
             add_action (ref launchers_group, Schema.MEDIA, _("Home Folder"), "home");
+            add_action (ref launchers_group, Schema.MEDIA, _("Music"), "media");
             add_action (ref launchers_group, Schema.MEDIA, _("Terminal"), "terminal");
             add_action (ref launchers_group, Schema.MEDIA, _("Internet Browser"), "www");
             add_action (ref launchers_group, Schema.WM, _("Applications Launcher"), "panel-main-menu");
@@ -92,7 +93,6 @@ namespace Pantheon.Keyboard.Shortcuts {
             add_action (ref media_group, Schema.MEDIA, _("Volume Up"), "volume-up");
             add_action (ref media_group, Schema.MEDIA, _("Volume Down"), "volume-down");
             add_action (ref media_group, Schema.MEDIA, _("Mute"), "volume-mute");
-            add_action (ref media_group, Schema.MEDIA, _("Launch Media Player"), "media");
             add_action (ref media_group, Schema.MEDIA, _("Play"), "play");
             add_action (ref media_group, Schema.MEDIA, _("Pause"), "pause");
             add_action (ref media_group, Schema.MEDIA, _("Stop"), "stop");


### PR DESCRIPTION
This moves the "Launch Media Player" shortcut to the applications section and renames it to be more specific since it launches Music and not Videos. The old label is a bit ambiguous about which will be opened.