### PR TITLE
Rewrite conflict dialog as a Granite.MessageDialog

### DIFF
--- a/src/Dialogs/ConflictDialog.vala
+++ b/src/Dialogs/ConflictDialog.vala
@@ -1,17 +1,42 @@
+/*
+* Copyright (c) 2017-2018 elementary, LLC. (https://elementary.io)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*/
 
-
-public class ConflictDialog : Gtk.MessageDialog {
-
+public class ConflictDialog : Granite.MessageDialog {
     public signal void reassign ();
 
     public ConflictDialog (string shortcut, string conflict_action, string this_action) {
+        Object (
+            image_icon: new GLib.ThemedIcon ("dialog-warning"),
+            primary_text: _("%s is already used for %s").printf (shortcut, conflict_action),
+            secondary_text: _("If you reassign the shortcut to %s, %s will be disabled.").printf (this_action, conflict_action)
+        );
+    }
+
+    construct {
+        deletable = false;
         modal = true;
-        message_type = Gtk.MessageType.WARNING;
-        text = _("%s is already used for %s!").printf (shortcut, conflict_action);
-        secondary_text = _("If you reassign the shortcut to %s, %s will be disabled").printf (this_action, conflict_action);
+        resizable = false;
 
         add_button (_("Cancel"), 0);
-        add_button (_("Reassign"), 1);
+
+        var reassign_button = add_button (_("Reassign"), 1);
+        reassign_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
         response.connect ((response_id) => {
             if (response_id == 1) {

--- a/src/Widgets/Shortcuts/CustomTree.vala
+++ b/src/Widgets/Shortcuts/CustomTree.vala
@@ -256,7 +256,8 @@ namespace Pantheon.Keyboard.Shortcuts {
                             CustomShortcutSettings.edit_shortcut ((string) relocatable_schema, not_null_shortcut.to_gsettings ());
                             load_and_display_custom_shortcuts ();
                         });
-                    dialog.show ();
+                    dialog.transient_for = (Gtk.Window) this.get_toplevel ();
+                    dialog.present ();
                     return false;
                 }
             }

--- a/src/Widgets/Shortcuts/Tree.vala
+++ b/src/Widgets/Shortcuts/Tree.vala
@@ -133,7 +133,8 @@ namespace Pantheon.Keyboard.Shortcuts {
                         settings.set_val ((Schema) schema, (string) key, shortcut);
                         load_and_display_shortcuts ();
                     });
-                    dialog.show ();
+                    dialog.transient_for = (Gtk.Window) this.get_toplevel ();
+                    dialog.present ();
                     return false;
                 }
             }


### PR DESCRIPTION
* Add a copyright header
* Subclass Granite.MessageDialog instead of Gtk.MessageDialog
* No terminating punctuation in primary text, but yes in secondary text
* Set action button as destructive style class
* Set `transient_for` so that we can center on the parent window
* GObject style

## Before

![screenshot from 2018-02-26 15 33 32](https://user-images.githubusercontent.com/7277719/36702057-710a9418-1b0a-11e8-827c-f13009290e5e.png)

## After
![screenshot from 2018-02-26 15 30 43](https://user-images.githubusercontent.com/7277719/36702025-534518cc-1b0a-11e8-9d0d-95531cd6c9ae.png)
