### PR TITLE
Change label of disabled caps lock key to match the others

### DIFF
--- a/src/Views/Layout.vala
+++ b/src/Views/Layout.vala
@@ -98,7 +98,7 @@ namespace Pantheon.Keyboard.LayoutPage {
             // Caps Lock key functionality
             modifier = new Xkb_modifier ();
             modifier.append_xkb_option ("", _("Default"));
-            modifier.append_xkb_option ("caps:none", _("Caps Lock disabled"));
+            modifier.append_xkb_option ("caps:none", _("Disabled"));
             modifier.append_xkb_option ("caps:backspace", _("as Backspace"));
             modifier.append_xkb_option ("ctrl:nocaps", _("as Ctrl"));
             modifier.append_xkb_option ("caps:escape", _("as Escape"));


### PR DESCRIPTION
The "Caps Lock disabled" entry in the Layout tab was inconsistent with the ones in the other menus. This PR changes its label to match the others.

This is a small change in a user-facing label -- the bulk of the edits are the updates to the po files since the old string has been folded into an existing message.