### PR TITLE
Use "Hankaku Zenkaku" instead of "Zenkaku Hankaku"

### DIFF
--- a/src/Views/Layout.vala
+++ b/src/Views/Layout.vala
@@ -285,7 +285,7 @@ namespace Pantheon.Keyboard.LayoutPage {
             var nicola_backspace_label = new SettingsLabel (_("Nicola F Backspace:"), size_group[0]);
             var nicola_backspace_switch = new XkbOptionSwitch (settings, "japan:nicola_f_bs");
 
-            var zenkaku_label = new SettingsLabel (_("Zenkaku Hankaku as Escape:"), size_group[0]);
+            var zenkaku_label = new SettingsLabel (_("Hankaku Zenkaku as Escape:"), size_group[0]);
             var zenkaku_switch = new XkbOptionSwitch (settings, "japan:hztg_escape");
 
             string [] valid_input_sources = {"jp"};


### PR DESCRIPTION
This is very tiny thing, but I think we should use "Hankaku Zenkaku" instead of "Zenkaku Hankaku", because the name of that key is "半角／全角キー (Hankaku/Zenkaku Key)", not "全角／半角キー (Zenkaku/Hankaku Key)". (See https://en.wikipedia.org/wiki/Language_input_keys#Half-width/Full-width/Kanji for more detail)
