### PR TITLE
Exclude space from single key shortcuts

### DIFF
--- a/src/Shortcuts/Shortcut.vala
+++ b/src/Shortcuts/Shortcut.vala
@@ -106,7 +106,7 @@ namespace Pantheon.Keyboard.Shortcuts
             if (accel_key == 0) {
                 return false;
             }
-            
+
             if (modifiers == (Gdk.ModifierType) 0 || modifiers == Gdk.ModifierType.SHIFT_MASK) {
                 if ((accel_key >= Gdk.Key.a                   && accel_key <= Gdk.Key.z)
                 || (accel_key >= Gdk.Key.A                    && accel_key <= Gdk.Key.Z)
@@ -139,6 +139,7 @@ namespace Pantheon.Keyboard.Shortcuts
                 || (accel_key == Gdk.Key.slash)
                 || (accel_key == Gdk.Key.period)
                 || (accel_key == Gdk.Key.comma)
+                || (accel_key == Gdk.Key.space)
                 || (accel_key == Gdk.Key.grave)) {
                    return false;
                }


### PR DESCRIPTION
#214 made it possible to create single key shortcuts. As I am used to disable keyboard shortcuts by clicking on the shortcut and pressing space, I earlier accidentally bound a shortcut to space. 

I think this should not be possible. In my opinion the space key should be in accordance to period, comma, grave etc. also be excluded from single key shortcuts.