### PR TITLE
Layout: lookup io.elementary.wingpanel.keyboard recursive

### DIFF
--- a/src/Views/Layout.vala
+++ b/src/Views/Layout.vala
@@ -146,7 +146,7 @@ namespace Pantheon.Keyboard.LayoutPage {
             attach (caps_lock_combo, 2, 3, 1, 1);
             attach (advanced_settings, 1, 4, 2);
 
-            if (GLib.SettingsSchemaSource.get_default ().lookup ("io.elementary.wingpanel.keyboard", false) != null) {
+            if (GLib.SettingsSchemaSource.get_default ().lookup ("io.elementary.wingpanel.keyboard", true) != null) {
                 var indicator_header = new Granite.HeaderLabel (_("Show in Panel"));
                 indicator_header.halign = Gtk.Align.END;
                 indicator_header.xalign = 1;


### PR DESCRIPTION
Still needs https://github.com/elementary/wingpanel-indicator-keyboard/pull/62

See https://github.com/elementary/wingpanel-indicator-notifications/pull/110 for details why I need this in NixOS. And docs say that you should pretty much always lookup recursive.