### PR TITLE
control: Runtime dependency on ibus

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Homepage: https://github.com/elementary/switchboard-plug-keyboard
 
 Package: switchboard-plug-keyboard
 Architecture: any
-Depends: xkb-data, ${misc:Depends}, ${shlibs:Depends}
+Depends: ibus, xkb-data, ${misc:Depends}, ${shlibs:Depends}
 Enhances: switchboard
 Description: Switchboard plug for keyboard settings
  This plug can be used to change several keyboard settings, for example the


### PR DESCRIPTION
Fixes #315 

Switchboard crashes on loading the `keyboard` module without the ibus GSettings schema installed