### PR TITLE
Release 2.4.2

### DIFF
--- a/data/io.elementary.switchboard.keyboard.appdata.xml.in
+++ b/data/io.elementary.switchboard.keyboard.appdata.xml.in
@@ -7,10 +7,13 @@
   <icon type="stock">preferences-desktop-keyboard</icon>
   <translation type="gettext">keyboard-plug</translation>
   <releases>
-    <release version="2.4.2" date="2020-09-24" urgency="medium">
+    <release version="2.4.2" date="2020-10-08" urgency="medium">
       <description>
-        <p>Add Layout popover is now a dialog</p>
-        <p>Updated translations</p>
+        <p>Minor updates</p>
+        <ul>
+          <li>Add Layout popover is now a dialog</li>
+          <li>Updated translations</li>
+        </ul>
       </description>
     </release>
     <release version="2.4.1" date="2020-09-02" urgency="medium">

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'keyboard',
     'vala', 'c',
-    version: '2.4.1'
+    version: '2.4.2'
 )
 
 gettext_name = meson.project_name() + '-plug'


### PR DESCRIPTION
Since it's been a while since a release including lots of translation commits, and we're still compatible with 5.x.

https://github.com/elementary/switchboard-plug-keyboard/compare/2.4.1...release-2.4.2