### PR TITLE
Fix not working ⌘ key behavior Application Menu

### DIFF
--- a/src/Views/Layout.vala
+++ b/src/Views/Layout.vala
@@ -179,7 +179,7 @@ namespace Pantheon.Keyboard {
                 case "":
                     overlay_key_combo.active = 0;
                     break;
-                case "wingpanel --toggle-indicator=app-launcher":
+                case "io.elementary.wingpanel --toggle-indicator=app-launcher":
                     overlay_key_combo.active = 1;
                     break;
                 case "io.elementary.shortcut-overlay":
@@ -193,7 +193,7 @@ namespace Pantheon.Keyboard {
                 if (combo_active == 0) {
                     gala_behavior_settings.set_string ("overlay-action", "");
                 } else if (combo_active == 1) {
-                    gala_behavior_settings.set_string ("overlay-action", "wingpanel --toggle-indicator=app-launcher");
+                    gala_behavior_settings.set_string ("overlay-action", "io.elementary.wingpanel --toggle-indicator=app-launcher");
                 } else if (combo_active == 2) {
                     gala_behavior_settings.set_string ("overlay-action", "io.elementary.shortcut-overlay");
                 }


### PR DESCRIPTION
⌘ key behavior: [Application menu] in Layout view no longer works because `wingpanel` became `io.elementary.wingpanel`. So this PR simply update the name of the wingpanel binary in the Layout view.

![LayoutView](https://user-images.githubusercontent.com/63053131/110464173-1bee7800-80d3-11eb-873a-b35441d8b775.png)
