### PR TITLE
InputMethod: Fix wrong copy of ibus panel label

### DIFF
--- a/src/Views/InputMethod.vala
+++ b/src/Views/InputMethod.vala
@@ -133,7 +133,7 @@ public class Pantheon.Keyboard.InputMethodPage.Page : Gtk.Grid {
         keyboard_shortcut_combobox.append ("shift-space", Granite.accel_to_string ("<Shift>space"));
         keyboard_shortcut_combobox.active_id = get_keyboard_shortcut ();
 
-        var show_ibus_panel_label = new Gtk.Label (_("Show candidate window:")) {
+        var show_ibus_panel_label = new Gtk.Label (_("Show property panel:")) {
             halign = Gtk.Align.END
         };
 


### PR DESCRIPTION
"Candidate window" is this:

![Screenshot from 2021-04-14 14-29-43](https://user-images.githubusercontent.com/26003928/114659203-203f2e00-9d2e-11eb-9b11-b56bac15bc1b.png)

And the preference here does not mean it and actually points this called "property panel":

![2021-04-14 14 30 47 のスクリーンショット](https://user-images.githubusercontent.com/26003928/114659247-364cee80-9d2e-11eb-87ea-233d458ee751.png)
