### PR TITLE
Ensure IBus daemon autostarts if (and only if) input methods are active

### DIFF
--- a/src/Views/InputMethod.vala
+++ b/src/Views/InputMethod.vala
@@ -362,6 +362,7 @@ public class Pantheon.Keyboard.InputMethodPage.Page : Gtk.Grid {
                 return;
             }
         }
+
         // Construct keyfile for ibus-daemon.desktop
         var languages = Intl.get_language_names ();
         var preferred_language = languages [0];
@@ -370,7 +371,7 @@ public class Pantheon.Keyboard.InputMethodPage.Page : Gtk.Grid {
         keyfile.set_locale_string (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_NAME, preferred_language, _("IBus Daemon"));
         keyfile.set_locale_string (
             KeyFileDesktop.GROUP, KeyFileDesktop.KEY_COMMENT, preferred_language,
-            _("IBus Daemon is a background service that enables you to use and manage input methods")
+            _("Use and manage input methods")
         );
         keyfile.set_string (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_EXEC, "ibus-daemon -drx");
         keyfile.set_string (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_ICON, "ibus-setup");

--- a/src/Views/InputMethod.vala
+++ b/src/Views/InputMethod.vala
@@ -351,12 +351,8 @@ public class Pantheon.Keyboard.InputMethodPage.Page : Gtk.Grid {
         var config_dir = Environment.get_user_config_dir ();
         var startup_dir = Path.build_filename (config_dir, "autostart");
 
-        if (startup_dir == "") {
-            return;
-        }
-
         // If startup directory doesn't exist, create it.
-        if (FileUtils.test (startup_dir, FileTest.EXISTS) == false) {
+        if (!FileUtils.test (startup_dir, FileTest.EXISTS)) {
             var file = File.new_for_path (startup_dir);
 
             try {
@@ -384,8 +380,7 @@ public class Pantheon.Keyboard.InputMethodPage.Page : Gtk.Grid {
         try {
             GLib.FileUtils.set_contents (path, keyfile.to_data ());
         } catch (Error e) {
-            warning ("Could not write to file %s", path);
-            warning (e.message);
+            warning ("Could not write to file %s: %s", path, e.message);
         }
     }
 

--- a/src/Views/InputMethod.vala
+++ b/src/Views/InputMethod.vala
@@ -318,8 +318,11 @@ public class Pantheon.Keyboard.InputMethodPage.Page : Gtk.Grid {
 
         listbox.show_all ();
         //Do not autoselect the first entry as that would change the active input method
-
         remove_button.sensitive = listbox.get_selected_row () != null;
+        // If ibus is running, update its autostart file according to whether there are input methods active
+        if (stack.visible_child_name == "main_view") {
+            write_ibus_autostart_file (listbox.get_children ().length () > 0);
+        }
     }
 
     private void spawn_ibus_daemon () {
@@ -337,6 +340,53 @@ public class Pantheon.Keyboard.InputMethodPage.Page : Gtk.Grid {
             return Gdk.EVENT_PROPAGATE;
         });
         timeout_start_daemon = 0;
+
+        if (is_spawn_succeeded & listbox.get_children ().length () > 0) {
+            write_ibus_autostart_file (true);
+        }
+    }
+
+    private void write_ibus_autostart_file (bool enable) {
+        // Get path to user's startup directory (typically ~/.config/autostart)
+        var config_dir = Environment.get_user_config_dir ();
+        var startup_dir = Path.build_filename (config_dir, "autostart");
+
+        if (startup_dir == "") {
+            return;
+        }
+
+        // If startup directory doesn't exist, create it.
+        if (FileUtils.test (startup_dir, FileTest.EXISTS) == false) {
+            var file = File.new_for_path (startup_dir);
+
+            try {
+                file.make_directory_with_parents ();
+            } catch (Error e) {
+                warning (e.message);
+                return;
+            }
+        }
+        // Construct keyfile for ibus-daemon.desktop
+        var languages = Intl.get_language_names ();
+        var preferred_language = languages [0];
+
+        var keyfile = new GLib.KeyFile ();
+        keyfile.set_locale_string (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_NAME, preferred_language, _("IBus Daemon"));
+        keyfile.set_locale_string (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_COMMENT, preferred_language, "ibus-daemon -drx");
+        keyfile.set_string (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_EXEC, "ibus-daemon -drx");
+        keyfile.set_string (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_ICON, "application-default-icon");
+        keyfile.set_string (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_TYPE, "Application");
+        keyfile.set_boolean (KeyFileDesktop.GROUP, "X-GNOME-Autostart-enabled", enable);
+
+        var path = Path.build_filename (startup_dir, "ibus-daemon.desktop");
+
+        // Create or update desktop file
+        try {
+            GLib.FileUtils.set_contents (path, keyfile.to_data ());
+        } catch (Error e) {
+            warning ("Could not write to file %s", path);
+            warning (e.message);
+        }
     }
 
     private void set_visible_view (string error_message = "") {

--- a/src/Views/InputMethod.vala
+++ b/src/Views/InputMethod.vala
@@ -368,9 +368,12 @@ public class Pantheon.Keyboard.InputMethodPage.Page : Gtk.Grid {
 
         var keyfile = new GLib.KeyFile ();
         keyfile.set_locale_string (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_NAME, preferred_language, _("IBus Daemon"));
-        keyfile.set_locale_string (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_COMMENT, preferred_language, "ibus-daemon -drx");
+        keyfile.set_locale_string (
+            KeyFileDesktop.GROUP, KeyFileDesktop.KEY_COMMENT, preferred_language,
+            _("IBus Daemon is a background service that enables you to use and manage input methods")
+        );
         keyfile.set_string (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_EXEC, "ibus-daemon -drx");
-        keyfile.set_string (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_ICON, "application-default-icon");
+        keyfile.set_string (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_ICON, "ibus-setup");
         keyfile.set_string (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_TYPE, "Application");
         keyfile.set_boolean (KeyFileDesktop.GROUP, "X-GNOME-Autostart-enabled", enable);
 


### PR DESCRIPTION
Fixes #https://github.com/elementary/wingpanel-indicator-keyboard/issues/105
fixes #379

 - When the IBus daemon is started manually a suitable desktop file is added to the user's autostart directory
 - Whether autostart is enabled depends on whether there are any input method engines active.

At the moment IBus is not autostarted, even if input method engines are added, unless the user activates the daemon using the "No Daemon" view.

At the moment, Wingpanel has a switch to turn the IBus daemon on and off temporarily but this setting is not remembered between sessions - IBus is still autostarted.  It should be considered whether turning this switch off should disable the autostart file - which would require another PR for wingpanel.