### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,3 +1,5 @@
 namespace Constants {
     public const string XKB_BASE = "@XKB_BASE@";
+    public const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
+    public const string LOCALEDIR = "@LOCALEDIR@";
 }

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -24,6 +24,9 @@ public class Pantheon.Keyboard.Plug : Switchboard.Plug {
     private Gtk.Stack stack;
 
     public Plug () {
+        GLib.Intl.bindtextdomain (Constants.GETTEXT_PACKAGE, Constants.LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (Constants.GETTEXT_PACKAGE, "UTF-8");
+
         var settings = new Gee.TreeMap<string, string?> (null, null);
         settings.set ("input/keyboard", "Layout");
         settings.set ("input/keyboard/layout", "Layout");

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,6 +3,8 @@ xkb_base = xkbconf.get_pkgconfig_variable('xkb_base')
 
 conf_data = configuration_data()
 conf_data.set('XKB_BASE', xkb_base)
+conf_data.set('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+conf_data.set('GETTEXT_PACKAGE', meson.project_name() + '-plug')
 config_file = configure_file (
     input: 'Config.vala.in',
     output: 'Config.vala',


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)