### PR TITLE
Disable layout switching if only one layout

### DIFF
--- a/src/InputSources/SourceSettings.vala
+++ b/src/InputSources/SourceSettings.vala
@@ -176,13 +176,19 @@ class Pantheon.Keyboard.SourceSettings : Object {
         input_sources.foreach (func);
     }
 
-    private void add_default_keyboard_if_required () {
-        bool have_xkb = false;
+    public uint get_n_xkb_layouts () {
+        uint n_xkb = 0;
         input_sources.@foreach ((source) => {
             if (source.layout_type == LayoutType.XKB) {
-                have_xkb = true;
+                n_xkb++;
             }
         });
+
+        return n_xkb;
+    }
+
+    private void add_default_keyboard_if_required () {
+        bool have_xkb = get_n_xkb_layouts () > 0;
 
         if (!have_xkb) {
             var file = File.new_for_path ("/etc/default/keyboard");

--- a/src/Views/Layout.vala
+++ b/src/Views/Layout.vala
@@ -176,6 +176,18 @@ namespace Pantheon.Keyboard {
                 show_panel_for_active_layout ();
             });
 
+            settings.external_layout_change.connect (() => {
+                var one_xkb = settings.get_n_xkb_layouts () <= 1;
+                if (one_xkb) {
+                    // Disable switching layouts when only one layout (so switching is ineffective anyway). This prevents some
+                    // shortcuts being blocked unnecessarily.
+                    switch_layout_combo.active_id = "";
+                    switch_layout_combo.sensitive = false;
+                } else {
+                    switch_layout_combo.sensitive = true;
+                }
+            });
+
             var gala_behavior_settings = new GLib.Settings ("org.pantheon.desktop.gala.behavior");
 
             var overlay_string = gala_behavior_settings.get_string ("overlay-action");
@@ -203,6 +215,8 @@ namespace Pantheon.Keyboard {
                     gala_behavior_settings.set_string ("overlay-action", "io.elementary.shortcut-overlay");
                 }
             });
+
+            settings.external_layout_change (); // Update switch_layout_combo on opening.
         }
 
         private AdvancedSettingsPanel? third_level_layouts_panel () {


### PR DESCRIPTION
Fixes #387 (when one layout).

This is a possible way of improving the situation with shortcuts that include `Alt + Shift`.  There are some unanswered questions:
 
 - Should the Switch Layout shortcut be disabled by default when a second layout is added? 
 - If not, what should be the default shortcut?
 - Can a less problematic default shortcut be used?
 - Should a warning be given if `Alt + Shift` (and similar) shortcut is chosen regarding possible impact on other shortcuts?
 - Is this shortcut disabled after installation? If not, should it be if there is only one layout?  Where is this done?
 