### PR TITLE
Control: Add Gala runtime dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Homepage: https://github.com/elementary/switchboard-plug-keyboard
 
 Package: switchboard-plug-keyboard
 Architecture: any
-Depends: gala (>=6.3.1),
+Depends: gala,
          ibus,
          xkb-data,
          ${misc:Depends},

--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,11 @@ Homepage: https://github.com/elementary/switchboard-plug-keyboard
 
 Package: switchboard-plug-keyboard
 Architecture: any
-Depends: ibus, xkb-data, ${misc:Depends}, ${shlibs:Depends}
+Depends: gala (>=6.3.1),
+         ibus,
+         xkb-data,
+         ${misc:Depends},
+         ${shlibs:Depends}
 Enhances: switchboard
 Description: Switchboard plug for keyboard settings
  This plug can be used to change several keyboard settings, for example the


### PR DESCRIPTION
Seems like we should runtime depend on Gala for its settings keys, and also now for the Super key behavior

- [ ] Depends on https://github.com/elementary/gala/pull/1398