### PR TITLE
Remove empty tooltip

### DIFF
--- a/src/Views/Layout.vala
+++ b/src/Views/Layout.vala
@@ -122,7 +122,8 @@ namespace Pantheon.Keyboard {
             };
 
             var onscreen_keyboard_settings = new Gtk.LinkButton.with_label ("", _("On-screen keyboard settings…")) {
-                halign = Gtk.Align.START
+                halign = Gtk.Align.START,
+                has_tooltip = false
             };
 
             // Advanced settings panel


### PR DESCRIPTION
Removes empty tooltip on "On-screen keyboard settings…" link button