### PR TITLE
ShortcutListBox: only add ShortcutRow when schema key is valid

### DIFF
--- a/src/Shortcuts/Settings.vala
+++ b/src/Shortcuts/Settings.vala
@@ -49,7 +49,7 @@ namespace Pantheon.Keyboard.Shortcuts {
             }
         }
 
-        private bool valid (Schema schema, string key) {
+        public bool valid (Schema schema, string key) {
             // check if schema exists
             if (schema < 0 || schema >= Schema.COUNT)
                 return false;

--- a/src/Widgets/Shortcuts/ShortcutListBox.vala
+++ b/src/Widgets/Shortcuts/ShortcutListBox.vala
@@ -35,10 +35,12 @@ private class Pantheon.Keyboard.Shortcuts.ShortcutListBox : Gtk.ListBox, Shortcu
         var sizegroup = new Gtk.SizeGroup (Gtk.SizeGroupMode.VERTICAL);
 
         for (int i = 0; i < actions.length; i++) {
-            var row = new ShortcutRow (actions[i], schemas[i], keys[i]);
-            add (row);
+            if (settings.valid (schemas[i], keys[i])) {
+                var row = new ShortcutRow (actions[i], schemas[i], keys[i]);
+                add (row);
 
-            sizegroup.add_widget (row);
+                sizegroup.add_widget (row);
+            }
         }
 
         show_all ();


### PR DESCRIPTION
This fixes a regression from c4988d9a3ed26e44fe61b3f09bb5dc071497ff4f.

The vanilla GSD does not know about the 'terminal' media-key, this result in a crash for non-ubuntu users. This restores the behavior before c4988d9, we just hide the row when the key is not valid.

https://git.launchpad.net/ubuntu/+source/gnome-settings-daemon/diff/debian/patches/ubuntu/media-keys-restore-terminal-keyboard-shortcut-schema.patch

- Closes https://github.com/elementary/switchboard-plug-keyboard/issues/426

![](https://user-images.githubusercontent.com/20080233/204127842-ff6bd7e2-0f59-4c9c-8e9d-3ffd2f66d6a7.png)
