### PR TITLE
InputMethod: Fix ProgressDialog is not used

### DIFF
--- a/src/Dialogs/InstallEngineDialog.vala
+++ b/src/Dialogs/InstallEngineDialog.vala
@@ -16,6 +16,7 @@
 */
 
 public class Pantheon.Keyboard.InputMethodPage.InstallEngineDialog : Granite.MessageDialog {
+    private Gtk.ListBox listbox;
     private InstallList? engines_filter;
 
     public InstallEngineDialog (Gtk.Window parent) {
@@ -52,7 +53,7 @@ public class Pantheon.Keyboard.InputMethodPage.InstallEngineDialog : Granite.Mes
         language_header.pack_start (back_button);
         language_header.set_center_widget (language_title);
 
-        var listbox = new Gtk.ListBox () {
+        listbox = new Gtk.ListBox () {
             expand = true
         };
         listbox.set_filter_func (filter_function);
@@ -115,13 +116,10 @@ public class Pantheon.Keyboard.InputMethodPage.InstallEngineDialog : Granite.Mes
             ((EnginesRow) listbox.get_selected_row ()).selected = true;
             install_button.sensitive = true;
         });
+    }
 
-        response.connect ((response_id) => {
-            if (response_id == Gtk.ResponseType.OK) {
-                string engine_to_install = ((EnginesRow) listbox.get_selected_row ()).engine_name;
-                UbuntuInstaller.get_default ().install (engine_to_install);
-            }
-        });
+    public string get_selected_engine_name () {
+        return ((EnginesRow) listbox.get_selected_row ()).engine_name;
     }
 
     [CCode (instance_pos = -1)]

--- a/src/Widgets/InputMethod/AddEnginesPopover.vala
+++ b/src/Widgets/InputMethod/AddEnginesPopover.vala
@@ -96,6 +96,7 @@ public class Pantheon.Keyboard.InputMethodPage.AddEnginesPopover : Gtk.Popover {
             install_dialog.response.connect ((response_id) => {
                 if (response_id == Gtk.ResponseType.OK) {
                     string engine_to_install = install_dialog.get_selected_engine_name ();
+                    install_dialog.destroy ();
                     installer.install (engine_to_install);
 
                     var progress_dialog = new ProgressDialog () {
@@ -106,10 +107,11 @@ public class Pantheon.Keyboard.InputMethodPage.AddEnginesPopover : Gtk.Popover {
                     });
                     progress_dialog.run ();
                     progress_dialog.destroy ();
+                } else {
+                    install_dialog.destroy ();
                 }
             });
             install_dialog.run ();
-            install_dialog.destroy ();
         });
 
         cancel_button.clicked.connect (() => {

--- a/src/Widgets/InputMethod/AddEnginesPopover.vala
+++ b/src/Widgets/InputMethod/AddEnginesPopover.vala
@@ -91,7 +91,23 @@ public class Pantheon.Keyboard.InputMethodPage.AddEnginesPopover : Gtk.Popover {
         install_button.clicked.connect (() => {
             popdown ();
 
+            var installer = UbuntuInstaller.get_default ();
             var install_dialog = new InstallEngineDialog ((Gtk.Window) get_toplevel ());
+            install_dialog.response.connect ((response_id) => {
+                if (response_id == Gtk.ResponseType.OK) {
+                    string engine_to_install = install_dialog.get_selected_engine_name ();
+                    installer.install (engine_to_install);
+
+                    var progress_dialog = new ProgressDialog () {
+                        transient_for = (Gtk.Window) get_toplevel ()
+                    };
+                    installer.progress_changed.connect ((p) => {
+                        progress_dialog.progress = p;
+                    });
+                    progress_dialog.run ();
+                    progress_dialog.destroy ();
+                }
+            });
             install_dialog.run ();
             install_dialog.destroy ();
         });


### PR DESCRIPTION
When I added InputMethod view in #287, I forgot to bring the logic to show the progress dialog from my InputMethod Plug. Thus, this dialog has been a died code since then and never been shown to user. This PR adds that logic and show the progress dialog while installing input method engine:

![screenshot](https://github.com/elementary/switchboard-plug-keyboard/assets/26003928/207e1da7-bbb7-4b42-b517-82cef8b59f6b)
