### PR TITLE
Check if `Granite.accel_to_string` returns `null`

### DIFF
--- a/src/Widgets/Shortcuts/CustomShortcutListBox.vala
+++ b/src/Widgets/Shortcuts/CustomShortcutListBox.vala
@@ -421,7 +421,12 @@ class Pantheon.Keyboard.Shortcuts.CustomShortcutListBox : Gtk.ListBox, ShortcutD
          }
 
         private void build_keycap_grid (string value_string, ref Gtk.Grid grid) {
-            var accels = Granite.accel_to_string (value_string).split (" + ");
+            var accels_string = Granite.accel_to_string (value_string);
+
+            string[] accels = {};
+            if (accels_string != null) {
+                accels = accels_string.split (" + ");
+            }
             foreach (unowned Gtk.Widget child in grid.get_children ()) {
                 child.destroy ();
             };

--- a/src/Widgets/Shortcuts/ShortcutListBox.vala
+++ b/src/Widgets/Shortcuts/ShortcutListBox.vala
@@ -323,12 +323,18 @@ private class Pantheon.Keyboard.Shortcuts.ShortcutListBox : Gtk.ListBox, Shortcu
             if (key_value.is_of_type (VariantType.ARRAY)) {
                 var key_value_strv = key_value.get_strv ();
                 if (key_value_strv.length > 0 && key_value_strv[0] != "") {
-                    accels = Granite.accel_to_string (key_value_strv[0]).split (" + ");
+                    var accels_string = Granite.accel_to_string (key_value_strv[0]);
+                    if (accels_string != null) {
+                        accels = accels_string.split (" + ");
+                    }
                 }
             } else {
                 var value_string = key_value.dup_string ();
                 if (value_string != "") {
-                    accels = Granite.accel_to_string (value_string).split (" + ");
+                    var accels_string = Granite.accel_to_string (value_string);
+                    if (accels_string != null) {
+                        accels = accels_string.split (" + ");
+                    }
                 }
             }
 


### PR DESCRIPTION
Avoid crash when there are incorrect keyboard shortcuts.