### PR TITLE
Shortcuts: GTK4 prep

### DIFF
--- a/src/Views/Shortcuts.vala
+++ b/src/Views/Shortcuts.vala
@@ -56,7 +56,7 @@ namespace Keyboard.Shortcuts {
         }
     }
 
-    class Page : Gtk.Grid {
+    class Page : Gtk.Box {
         private Gtk.ListBox section_switcher;
         private SwitcherRow custom_shortcuts_row;
 
@@ -79,22 +79,23 @@ namespace Keyboard.Shortcuts {
 
             section_switcher.select_row (section_switcher.get_row_at_index (0));
 
-            var scrolled_window = new Gtk.ScrolledWindow (null, null) {
-                child = section_switcher
+            var switcher_scrolled = new Gtk.ScrolledWindow (null, null) {
+                child = section_switcher,
+                hscrollbar_policy = NEVER
             };
 
             var switcher_frame = new Gtk.Frame (null) {
-                child = scrolled_window
+                child = switcher_scrolled
             };
 
             var stack = new Gtk.Stack () {
-                homogeneous = false
-            };
-
-            var scrolledwindow = new Gtk.ScrolledWindow (null, null) {
-                child = stack,
+                homogeneous = false,
                 hexpand = true,
                 vexpand = true
+            };
+
+            var stack_scrolled = new Gtk.ScrolledWindow (null, null) {
+                child = stack
             };
 
             var add_button_label = new Gtk.Label (_("Add Shortcut"));
@@ -104,6 +105,7 @@ namespace Keyboard.Shortcuts {
             add_button_box.add (add_button_label);
 
             var add_button = new Gtk.Button () {
+                child = add_button_box,
                 margin_top = 3,
                 margin_bottom = 3
             };
@@ -118,20 +120,19 @@ namespace Keyboard.Shortcuts {
             actionbar.pack_start (add_button);
 
             var action_box = new Gtk.Box (VERTICAL, 0);
-            action_box.add (scrolled_window);
+            action_box.add (stack_scrolled);
             action_box.add (actionbar);
 
             var frame = new Gtk.Frame (null) {
                 child = action_box
             };
 
-            column_spacing = 12;
-            column_homogeneous = true;
+            spacing = 12;
             margin_start = 12;
             margin_end = 12;
             margin_bottom = 12;
-            attach (switcher_frame, 0, 0);
-            attach (frame, 1, 0, 2, 1);
+            add (switcher_frame);
+            add (frame);
 
             for (int id = 0; id < SectionID.CUSTOM; id++) {
                 shortcut_views += new ShortcutListBox ((SectionID) id);
@@ -152,7 +153,7 @@ namespace Keyboard.Shortcuts {
                 var index = row.get_index ();
                 stack.visible_child = shortcut_views[index];
 
-                actionbar.visible = index == SectionID.CUSTOM;
+                actionbar.visible = stack.visible_child is CustomShortcutListBox;
             });
         }
 

--- a/src/Views/Shortcuts.vala
+++ b/src/Views/Shortcuts.vala
@@ -77,8 +77,6 @@ namespace Keyboard.Shortcuts {
             custom_shortcuts_row = new SwitcherRow (list.custom_group);
             section_switcher.add (custom_shortcuts_row);
 
-            section_switcher.select_row (section_switcher.get_row_at_index (0));
-
             var switcher_scrolled = new Gtk.ScrolledWindow (null, null) {
                 child = section_switcher,
                 hscrollbar_policy = NEVER
@@ -89,8 +87,7 @@ namespace Keyboard.Shortcuts {
             };
 
             var stack = new Gtk.Stack () {
-                homogeneous = false,
-                hexpand = true,
+                homogeneous = false, // Prevents extra scrollbar in short lists
                 vexpand = true
             };
 
@@ -154,6 +151,11 @@ namespace Keyboard.Shortcuts {
                 stack.visible_child = shortcut_views[index];
 
                 actionbar.visible = stack.visible_child is CustomShortcutListBox;
+            });
+
+            // Doing this too early makes the actionbar show by default
+            realize.connect (() => {
+                section_switcher.select_row (section_switcher.get_row_at_index (0));
             });
         }
 

--- a/src/Views/Shortcuts.vala
+++ b/src/Views/Shortcuts.vala
@@ -79,40 +79,51 @@ namespace Keyboard.Shortcuts {
 
             section_switcher.select_row (section_switcher.get_row_at_index (0));
 
-            var scrolled_window = new Gtk.ScrolledWindow (null, null);
-            scrolled_window.add (section_switcher);
+            var scrolled_window = new Gtk.ScrolledWindow (null, null) {
+                child = section_switcher
+            };
 
-            var switcher_frame = new Gtk.Frame (null);
-            switcher_frame.add (scrolled_window);
+            var switcher_frame = new Gtk.Frame (null) {
+                child = scrolled_window
+            };
 
-            var stack = new Gtk.Stack ();
-            stack.homogeneous = false;
+            var stack = new Gtk.Stack () {
+                homogeneous = false
+            };
 
-            var scrolledwindow = new Gtk.ScrolledWindow (null, null);
-            scrolledwindow.expand = true;
-            scrolledwindow.add (stack);
+            var scrolledwindow = new Gtk.ScrolledWindow (null, null) {
+                child = stack,
+                hexpand = true,
+                vexpand = true
+            };
 
-            var add_button = new Gtk.Button.with_label (_("Add Shortcut")) {
-                always_show_image = true,
-                image = new Gtk.Image.from_icon_name ("list-add-symbolic", Gtk.IconSize.SMALL_TOOLBAR),
+            var add_button_label = new Gtk.Label (_("Add Shortcut"));
+
+            var add_button_box = new Gtk.Box (HORIZONTAL, 0);
+            add_button_box.add (new Gtk.Image.from_icon_name ("list-add-symbolic", BUTTON));
+            add_button_box.add (add_button_label);
+
+            var add_button = new Gtk.Button () {
                 margin_top = 3,
                 margin_bottom = 3
             };
             add_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
-            var actionbar = new Gtk.ActionBar ();
-            actionbar.hexpand = true;
-            actionbar.no_show_all = true;
-            actionbar.get_style_context ().add_class (Gtk.STYLE_CLASS_INLINE_TOOLBAR);
+            add_button_label.mnemonic_widget = add_button;
+
+            var actionbar = new Gtk.ActionBar () {
+                hexpand = true
+            };
             actionbar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-            actionbar.add (add_button);
+            actionbar.pack_start (add_button);
 
-            var action_grid = new Gtk.Grid ();
-            action_grid.attach (scrolledwindow, 0, 0);
-            action_grid.attach (actionbar, 0, 1);
+            var action_box = new Gtk.Box (VERTICAL, 0);
+            action_box.add (scrolled_window);
+            action_box.add (actionbar);
 
-            var frame = new Gtk.Frame (null);
-            frame.add (action_grid);
+            var frame = new Gtk.Frame (null) {
+                child = action_box
+            };
 
             column_spacing = 12;
             column_homogeneous = true;
@@ -141,9 +152,7 @@ namespace Keyboard.Shortcuts {
                 var index = row.get_index ();
                 stack.visible_child = shortcut_views[index];
 
-                actionbar.no_show_all = index != SectionID.CUSTOM;
                 actionbar.visible = index == SectionID.CUSTOM;
-                show_all ();
             });
         }
 
@@ -161,16 +170,17 @@ namespace Keyboard.Shortcuts {
             construct {
                 var icon = new Gtk.Image.from_icon_name (group.icon_name, Gtk.IconSize.DND);
 
-                var label = new Gtk.Label (group.label);
-                label.xalign = 0;
+                var label = new Gtk.Label (group.label) {
+                    xalign = 0
+                };
 
-                var grid = new Gtk.Grid ();
-                grid.margin = 6;
-                grid.column_spacing = 6;
-                grid.add (icon);
-                grid.add (label);
+                var box = new Gtk.Box (HORIZONTAL, 6) {
+                    margin = 6
+                };
+                box.add (icon);
+                box.add (label);
 
-                add (grid);
+                child = box;
             }
         }
     }


### PR DESCRIPTION
* Replace grid with Box
* Use child property
* explicit expands
* rename variables to be less ambiguous (no `scrolledwindow` and `scrolled_window`)
* Construct add button in GTK4 friendly way (make sure screen reader can still read it)