### PR TITLE
Use get_row_at_index

### DIFF
--- a/src/InputSources/SourceSettings.vala
+++ b/src/InputSources/SourceSettings.vala
@@ -159,10 +159,6 @@ class Keyboard.SourceSettings : Object {
         input_sources.foreach (func);
     }
 
-    public int get_n_items () {
-        return (int) input_sources.length ();
-    }
-
     private void add_default_keyboard_if_required () {
         bool have_xkb = false;
         input_sources.@foreach ((source) => {

--- a/src/InputSources/SourceSettings.vala
+++ b/src/InputSources/SourceSettings.vala
@@ -159,6 +159,10 @@ class Keyboard.SourceSettings : Object {
         input_sources.foreach (func);
     }
 
+    public int get_n_items () {
+        return (int) input_sources.length ();
+    }
+
     private void add_default_keyboard_if_required () {
         bool have_xkb = false;
         input_sources.@foreach ((source) => {

--- a/src/Views/InputMethod.vala
+++ b/src/Views/InputMethod.vala
@@ -303,7 +303,7 @@ public class Keyboard.InputMethodPage.Page : Gtk.Box {
         engines = bus.list_engines ();
 
         while (listbox.get_row_at_index (0) != null) {
-            listbox.get_row_at_index (0).destroy ();
+            listbox.remove (listbox.get_row_at_index (0));
         };
 
         // Add the language and the name of activated engines

--- a/src/Views/InputMethod.vala
+++ b/src/Views/InputMethod.vala
@@ -302,9 +302,9 @@ public class Keyboard.InputMethodPage.Page : Gtk.Box {
     private void update_engines_list () {
         engines = bus.list_engines ();
 
-        listbox.@foreach ((listbox_child) => {
-            listbox_child.destroy ();
-        });
+        while (listbox.get_row_at_index (0) != null) {
+            listbox.get_row_at_index (0).destroy ();
+        };
 
         // Add the language and the name of activated engines
         settings.reset (LayoutType.IBUS);
@@ -336,7 +336,7 @@ public class Keyboard.InputMethodPage.Page : Gtk.Box {
         remove_button.sensitive = listbox.get_selected_row () != null;
         // If ibus is running, update its autostart file according to whether there are input methods active
         if (stack.visible_child_name == "main_view") {
-            write_ibus_autostart_file (listbox.get_children ().length () > 0);
+            write_ibus_autostart_file (listbox.get_row_at_index (0) != null);
         }
     }
 
@@ -356,7 +356,7 @@ public class Keyboard.InputMethodPage.Page : Gtk.Box {
         });
         timeout_start_daemon = 0;
 
-        if (is_spawn_succeeded & listbox.get_children ().length () > 0) {
+        if (is_spawn_succeeded & listbox.get_row_at_index (0) != null) {
             write_ibus_autostart_file (true);
         }
     }

--- a/src/Widgets/Layout/Display.vala
+++ b/src/Widgets/Layout/Display.vala
@@ -113,9 +113,9 @@ public class Keyboard.LayoutPage.Display : Gtk.Frame {
     }
 
     public void rebuild_list () {
-        foreach (unowned var child in list.get_children ()) {
-            list.remove (child);
-        }
+        while (list.get_row_at_index (0) != null) {
+            list.get_row_at_index (0).destroy ();
+        };
 
         uint i = 0;
         settings.foreach_layout ((input_source) => {
@@ -142,12 +142,11 @@ public class Keyboard.LayoutPage.Display : Gtk.Frame {
             i++;
         });
 
-        var list_children = list.get_children ();
-        if (!list_children.is_empty ()) {
-            unowned var first_child = (DisplayRow) list_children.first ().data;
+        if (list.get_row_at_index (0) != null) {
+            unowned var first_child = (DisplayRow) list.get_row_at_index (0);
             first_child.up_button.sensitive = false;
 
-            unowned var last_child = (DisplayRow) list_children.last ().data;
+            unowned var last_child = (DisplayRow) list.get_row_at_index (settings.get_n_items () - 1);
             last_child.down_button.sensitive = false;
         }
 

--- a/src/Widgets/Layout/Display.vala
+++ b/src/Widgets/Layout/Display.vala
@@ -146,7 +146,14 @@ public class Keyboard.LayoutPage.Display : Gtk.Frame {
             unowned var first_child = (DisplayRow) list.get_row_at_index (0);
             first_child.up_button.sensitive = false;
 
-            unowned var last_child = (DisplayRow) list.get_children ().last ().data;
+            // Avoid expensive observe children
+            DisplayRow last_child;
+            if (list.get_row_at_index (1) == null) {
+                last_child = (DisplayRow) list.get_row_at_index (0);
+            } else {
+                last_child = (DisplayRow) list.get_children ().last ().data;
+            }
+
             last_child.down_button.sensitive = false;
         }
 

--- a/src/Widgets/Layout/Display.vala
+++ b/src/Widgets/Layout/Display.vala
@@ -146,7 +146,7 @@ public class Keyboard.LayoutPage.Display : Gtk.Frame {
             unowned var first_child = (DisplayRow) list.get_row_at_index (0);
             first_child.up_button.sensitive = false;
 
-            unowned var last_child = (DisplayRow) list.get_row_at_index (settings.get_n_items () - 1);
+            unowned var last_child = (DisplayRow) list.get_children ().last ().data;
             last_child.down_button.sensitive = false;
         }
 

--- a/src/Widgets/Layout/Display.vala
+++ b/src/Widgets/Layout/Display.vala
@@ -114,7 +114,7 @@ public class Keyboard.LayoutPage.Display : Gtk.Frame {
 
     public void rebuild_list () {
         while (list.get_row_at_index (0) != null) {
-            list.get_row_at_index (0).destroy ();
+            list.remove (list.get_row_at_index (0));
         };
 
         uint i = 0;

--- a/src/Widgets/Layout/Display.vala
+++ b/src/Widgets/Layout/Display.vala
@@ -146,14 +146,9 @@ public class Keyboard.LayoutPage.Display : Gtk.Frame {
             unowned var first_child = (DisplayRow) list.get_row_at_index (0);
             first_child.up_button.sensitive = false;
 
-            // Avoid expensive observe children
-            DisplayRow last_child;
-            if (list.get_row_at_index (1) == null) {
-                last_child = (DisplayRow) list.get_row_at_index (0);
-            } else {
-                last_child = (DisplayRow) list.get_children ().last ().data;
-            }
-
+            int index = 0;
+            while (list.get_row_at_index (index) != null) { index++; }
+            unowned var last_child = (DisplayRow) list.get_row_at_index (index - 1);
             last_child.down_button.sensitive = false;
         }
 

--- a/src/Widgets/Shortcuts/CustomShortcutListBox.vala
+++ b/src/Widgets/Shortcuts/CustomShortcutListBox.vala
@@ -33,8 +33,8 @@ class Keyboard.Shortcuts.CustomShortcutListBox : Gtk.Box {
     }
 
     public void load_and_display_custom_shortcuts () {
-        foreach (Gtk.Widget child in list_box.get_children ()) {
-            child.destroy ();
+        while (list_box.get_row_at_index (0) != null) {
+            list_box.get_row_at_index (0).destroy ();
         }
 
         foreach (var custom_shortcut in CustomShortcutSettings.list_custom_shortcuts ()) {

--- a/src/Widgets/Shortcuts/CustomShortcutListBox.vala
+++ b/src/Widgets/Shortcuts/CustomShortcutListBox.vala
@@ -34,7 +34,7 @@ class Keyboard.Shortcuts.CustomShortcutListBox : Gtk.Box {
 
     public void load_and_display_custom_shortcuts () {
         while (list_box.get_row_at_index (0) != null) {
-            list_box.get_row_at_index (0).destroy ();
+            list_box.remove (list_box.get_row_at_index (0));
         }
 
         foreach (var custom_shortcut in CustomShortcutSettings.list_custom_shortcuts ()) {


### PR DESCRIPTION
Can't use `get_children` in GTK4, so use `get_row_at_index` where it makes sense. Use `remove` instead of `destroy` to avoid an infinite loop in GTK 4 where widgets are destroyed but not removed