### PR TITLE
Shortcuts: update category icons

### DIFF
--- a/data/screenshots.svg
+++ b/data/screenshots.svg
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="32"
    height="32"
-   id="svg4151">
+   id="svg4151"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4153">
     <linearGradient
@@ -20,11 +19,11 @@
          style="stop-color:#ffffff;stop-opacity:1"
          id="stop4283" />
       <stop
-         offset="0.02591527"
+         offset="0.07475055"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
          id="stop4285" />
       <stop
-         offset="0.95833325"
+         offset="0.93857974"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
          id="stop4287" />
       <stop
@@ -40,7 +39,7 @@
        id="linearGradient3174"
        xlink:href="#linearGradient4281"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.78378379,0,0,0.67567568,-2.8108117,-0.22000024)" />
+       gradientTransform="matrix(0.67567568,0,0,0.67567568,-0.21621703,-0.21620627)" />
     <radialGradient
        cx="4.9929786"
        cy="43.5"
@@ -50,7 +49,7 @@
        id="radialGradient2976"
        xlink:href="#linearGradient3688-166-749-6"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.6030273,0,0,0.59999988,19.990504,3.4000047)" />
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
     <linearGradient
        id="linearGradient3688-166-749-6">
       <stop
@@ -71,7 +70,7 @@
        id="radialGradient2978"
        xlink:href="#linearGradient3688-464-309-7"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.6030273,0,0,0.59999988,-12.009497,-55.599994)" />
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
     <linearGradient
        id="linearGradient3688-464-309-7">
       <stop
@@ -90,8 +89,7 @@
        y2="39.999443"
        id="linearGradient2980"
        xlink:href="#linearGradient3702-501-757-3"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.85714282,0,0,0.42857134,-4.571428,10.857146)" />
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
        id="linearGradient3702-501-757-3">
       <stop
@@ -107,6 +105,16 @@
          style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.39994776,-0.79806438,-1.1998291,0.59855136,1276.2546,-586.23106)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3764"
+       id="radialGradient4407"
+       fy="1039.7"
+       fx="14.999991"
+       r="3.5266583"
+       cy="1039.7"
+       cx="14.999991" />
     <linearGradient
        id="linearGradient3764">
       <stop
@@ -118,83 +126,6 @@
          style="stop-color:#eaeaea;stop-opacity:1"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient3242-7-6">
-      <stop
-         id="stop3244-6-4"
-         style="stop-color:#f89b7e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246-7-5"
-         style="stop-color:#e35d4f;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248-8-6"
-         style="stop-color:#c6262e;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250-6-8"
-         style="stop-color:#690b2c;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4685">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4687" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop4689" />
-    </linearGradient>
-    <linearGradient
-       id="outerBackgroundGradient-5-0">
-      <stop
-         id="stop3864-8-6-4"
-         style="stop-color:#261e2b;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3866-9-1-86"
-         style="stop-color:#352f39;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="10"
-       y1="-3"
-       x2="20"
-       y2="12"
-       id="linearGradient3887"
-       xlink:href="#linearGradient4685"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1524956,0,0,1.0173579,-8.1367574,11.138862)" />
-    <linearGradient
-       id="linearGradient4526"
-       osb:paint="solid">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop4528" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#outerBackgroundGradient-5-0"
-       id="linearGradient1272"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1481481,0,0,1,-67.062658,-59.931969)"
-       x1="18.566542"
-       y1="95.480614"
-       x2="18.566542"
-       y2="57.831203" />
-    <radialGradient
-       gradientTransform="matrix(-0.39994776,-0.79806438,-1.1998291,0.59855136,1276.2546,-586.23106)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3764"
-       id="radialGradient4407"
-       fy="1039.7"
-       fx="14.999991"
-       r="3.5266583"
-       cy="1039.7"
-       cx="14.999991" />
     <radialGradient
        gradientTransform="matrix(0.39994776,-0.79806438,1.1998291,0.59855136,-1225.064,-586.23106)"
        gradientUnits="userSpaceOnUse"
@@ -216,6 +147,25 @@
        cy="9.9941158"
        cx="8.8626814" />
     <linearGradient
+       id="linearGradient3242-7-6">
+      <stop
+         id="stop3244-6-4"
+         style="stop-color:#f89b7e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-7-5"
+         style="stop-color:#e35d4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-8-6"
+         style="stop-color:#c6262e;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-6-8"
+         style="stop-color:#690b2c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
        gradientTransform="matrix(0.49043499,0,0,0.50045513,1.0074558,0.78026574)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient4685"
@@ -225,6 +175,17 @@
        y1="40"
        x1="56" />
     <linearGradient
+       id="linearGradient4685">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4687" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop4689" />
+    </linearGradient>
+    <linearGradient
        gradientTransform="matrix(-0.49043499,0,0,0.50045513,50.23125,0.78026596)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient4685"
@@ -233,6 +194,35 @@
        x2="58.032764"
        y1="40"
        x1="56" />
+    <linearGradient
+       xlink:href="#outerBackgroundGradient-5-0"
+       id="linearGradient4158"
+       x1="41.609329"
+       y1="241.85577"
+       x2="41.609329"
+       y2="136.2437"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.26213595,0,0,0.26213592,-0.77669845,-33.563582)" />
+    <linearGradient
+       id="outerBackgroundGradient-5-0">
+      <stop
+         id="stop3864-8-6-4"
+         offset="0"
+         style="stop-color:#261e2b;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-86"
+         offset="1"
+         style="stop-color:#352f39;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4685"
+       id="linearGradient2019"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2186956,0,0,1.0656376,-9.5231885,10.646196)"
+       x1="10"
+       y1="-3"
+       x2="20"
+       y2="12" />
   </defs>
   <metadata
      id="metadata4156">
@@ -242,70 +232,75 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <g
+     style="display:inline"
+     id="g2036-2"
+     transform="matrix(0.6999997,0,0,0.3333336,-0.8000002,15.33333)">
+    <g
+       style="opacity:0.4"
+       id="g3712-3"
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+      <rect
+         style="fill:url(#radialGradient2976);fill-opacity:1;stroke:none"
+         id="rect2801-0"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient2978);fill-opacity:1;stroke:none"
+         id="rect3696-2"
+         transform="scale(-1,-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient2980);fill-opacity:1;stroke:none"
+         id="rect3700-1"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
+    </g>
+  </g>
   <rect
-     style="opacity:0.4;fill:url(#radialGradient2976);fill-opacity:1;stroke:none;stroke-width:0.561951"
-     id="rect2801-0"
-     y="28"
-     x="28"
-     height="2.9999993"
-     width="4" />
-  <rect
-     style="opacity:0.4;fill:url(#radialGradient2978);fill-opacity:1;stroke:none;stroke-width:0.561951"
-     id="rect3696-2"
-     transform="scale(-1)"
-     y="-30.999998"
-     x="-4"
-     height="2.9999993"
-     width="4" />
-  <rect
-     style="opacity:0.4;fill:url(#linearGradient2980);fill-opacity:1;stroke:none;stroke-width:0.561951"
-     id="rect3700-1"
-     y="28"
-     x="4"
-     height="2.9999995"
-     width="24" />
-  <rect
-     style="color:#000000;font-variation-settings:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1272);fill-opacity:1;fill-rule:nonzero;stroke:#170014;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.7;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4158);fill-opacity:1;fill-rule:nonzero;stroke:#1a0e1f;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.7;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variation-settings:normal;vector-effect:none;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
      id="rect5505-21"
      y="2.5"
-     x="0.49999997"
+     x="2.5000002"
      ry="3"
-     rx="2.9999998"
+     rx="3"
      height="27"
-     width="30.999998" />
+     width="27" />
   <rect
      style="opacity:0.3;fill:none;stroke:url(#linearGradient3174);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect6741-7-4"
      y="3.4999998"
-     x="1.5"
+     x="3.5"
      ry="2"
      rx="2"
      height="25"
-     width="29" />
+     width="25" />
   <path
-     id="rect3872"
-     style="display:inline;opacity:0.2;fill:url(#linearGradient3887);fill-opacity:1;stroke:none;stroke-width:1.33358"
-     d="M 3.4421619,3 C 2.3898982,3 1,4.2088456 1,5.112974 V 19 L 31,10.310119 V 5.112974 C 31,4.2088456 29.989794,3 28.620389,3 Z" />
+     id="rect3872-3-2"
+     style="display:inline;opacity:0.15;fill:url(#linearGradient2019);fill-opacity:1;stroke:none;stroke-width:1.33358"
+     d="M 5.5 2.5 C 3.8380017 2.5 2.5 3.8380017 2.5 5.5 L 2.5 18.203125 L 29.5 10.455078 L 29.5 5.5 C 29.5 3.8380017 28.161998 2.5 26.5 2.5 L 5.5 2.5 z " />
   <path
-     style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
-     id="path4477-4-2"
-     d="m 11,10 v 1 h 4 v -1 z m 6,0 v 1 h 4 V 10 Z M 6,15 v 4 h 1 v -4 z m 19,0 v 4 h 1 v -4 z m -14,8 v 1 h 4 v -1 z m 6,0 v 1 h 4 v -1 z" />
+     id="rect3540-2"
+     style="font-variation-settings:normal;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;opacity:0.3;stop-opacity:1"
+     d="M 7.5,9 C 6.6690016,9 6,9.6690016 6,10.5 V 12 H 7 V 10.75 C 7,10.334501 7.3345008,10 7.75,10 H 9 V 9 Z M 11,9 v 1 h 4 V 9 Z m 6,0 v 1 h 4 V 9 Z m 6,0 v 1 h 1.25 C 24.6655,10 25,10.334501 25,10.75 V 12 h 1 V 10.5 C 26,9.6690016 25.330998,9 24.5,9 Z M 6,15 v 4 h 1 v -4 z m 19,0 v 4 h 1 V 15 Z M 6,22 v 1.5 C 6,24.330998 6.6690016,25 7.5,25 H 9 V 24 H 7.75 C 7.3345008,24 7,23.6655 7,23.25 V 22 Z m 19,0 v 1.25 C 25,23.6655 24.6655,24 24.25,24 H 23 v 1 h 1.5 C 25.330998,25 26,24.330998 26,23.5 V 22 Z m -14,2 v 1 h 4 v -1 z m 6,0 v 1 h 4 v -1 z" />
   <path
-     style="font-variation-settings:normal;opacity:0.65;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
-     id="path4477-4-9"
-     d="m 11,9 v 1 h 4 V 9 Z m 6,0 v 1 h 4 V 9 Z M 6,14 v 4 h 1 v -4 z m 19,0 v 4 h 1 v -4 z m -14,8 v 1 h 4 v -1 z m 6,0 v 1 h 4 v -1 z" />
+     id="rect3540-2-7"
+     style="font-variation-settings:normal;opacity:0.15;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     d="M 7.5,7.9882812 C 6.1261875,7.9882813 4.9882812,9.1261875 4.9882812,10.5 V 12 A 1.0114836,1.0114836 0 0 0 6,13.011719 H 7 A 1.0114836,1.0114836 0 0 0 8.0117188,12 V 11.011719 H 9 a 1.0114836,1.0114836 0 0 0 1,-1 1.0114836,1.0114836 0 0 0 1,1 h 4 a 1.0114836,1.0114836 0 0 0 1,-1 1.0114836,1.0114836 0 0 0 1,1 h 4 a 1.0114836,1.0114836 0 0 0 1,-1 1.0114836,1.0114836 0 0 0 1,1 h 0.988281 V 12 A 1.0114836,1.0114836 0 0 0 25,13.011719 h 1 A 1.0114836,1.0114836 0 0 0 27.011719,12 V 10.5 C 27.011719,9.1261872 25.873812,7.9882813 24.5,7.9882812 H 23 a 1.0114836,1.0114836 0 0 0 -1,1 1.0114836,1.0114836 0 0 0 -1,-1 h -4 a 1.0114836,1.0114836 0 0 0 -1,1 1.0114836,1.0114836 0 0 0 -1,-1 h -4 a 1.0114836,1.0114836 0 0 0 -1,1 1.0114836,1.0114836 0 0 0 -1,-1 z M 6,13.988281 A 1.0114836,1.0114836 0 0 0 4.9882812,15 v 4 A 1.0114836,1.0114836 0 0 0 6,20.011719 H 7 A 1.0114836,1.0114836 0 0 0 8.0117188,19 V 15 A 1.0114836,1.0114836 0 0 0 7,13.988281 Z m 19,0 A 1.0114836,1.0114836 0 0 0 23.988281,15 v 4 A 1.0114836,1.0114836 0 0 0 25,20.011719 h 1 A 1.0114836,1.0114836 0 0 0 27.011719,19 V 15 A 1.0114836,1.0114836 0 0 0 26,13.988281 Z m -19,7 A 1.0114836,1.0114836 0 0 0 4.9882812,22 v 1.5 c 0,1.373812 1.137906,2.511719 2.5117188,2.511719 H 9 a 1.0114836,1.0114836 0 0 0 1,-1 1.0114836,1.0114836 0 0 0 1,1 h 4 a 1.0114836,1.0114836 0 0 0 1,-1 1.0114836,1.0114836 0 0 0 1,1 h 4 a 1.0114836,1.0114836 0 0 0 1,-1 1.0114836,1.0114836 0 0 0 1,1 h 1.5 c 1.373813,0 2.511719,-1.137906 2.511719,-2.511719 V 22 A 1.0114836,1.0114836 0 0 0 26,20.988281 H 25 A 1.0114836,1.0114836 0 0 0 23.988281,22 v 0.988281 H 23 a 1.0114836,1.0114836 0 0 0 -1,1 1.0114836,1.0114836 0 0 0 -1,-1 h -4 a 1.0114836,1.0114836 0 0 0 -1,1 1.0114836,1.0114836 0 0 0 -1,-1 h -4 a 1.0114836,1.0114836 0 0 0 -1,1 1.0114836,1.0114836 0 0 0 -1,-1 H 8.0117188 V 22 A 1.0114836,1.0114836 0 0 0 7,20.988281 Z" />
   <path
-     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="path2387-0-1-2-8"
-     d="m 25.466752,21.5 c 0,2 0,2 -1.966752,2 m -15,-0.01662 c -2,0 -2,0 -2,-1.966752 m 18.966752,-9.000004 c 0,-2 0,-2 -1.966752,-2 m -15,0.01662 c -2,0 -2,0 -2,1.966752" />
-  <path
-     style="font-variation-settings:normal;opacity:0.65;vector-effect:none;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
-     id="path2387-0-1-2"
-     d="m 25.466752,20.5 c 0,2 0,2 -1.966752,2 m -15,-0.01662 c -2,0 -2,0 -2,-1.966752 m 18.966752,-9.000004 c 0,-2 0,-2 -1.966752,-2 m -15,0.01662 c -2,0 -2,0 -2,1.966752" />
+     id="rect3540"
+     style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.7;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     d="M 7.5,8 C 6.6690016,8 6,8.6690016 6,9.5 V 11 H 7 V 9.75 C 7,9.3345008 7.3345008,9 7.75,9 H 9 V 8 Z M 11,8 v 1 h 4 V 8 Z m 6,0 v 1 h 4 V 8 Z m 6,0 v 1 h 1.25 C 24.6655,9 25,9.3345008 25,9.75 V 11 h 1 V 9.5 C 26,8.6690016 25.330998,8 24.5,8 Z M 6,14 v 4 h 1 v -4 z m 19,0 v 4 h 1 V 14 Z M 6,21 v 1.5 C 6,23.330998 6.6690016,24 7.5,24 H 9 V 23 H 7.75 C 7.3345008,23 7,22.6655 7,22.25 V 21 Z m 19,0 v 1.25 C 25,22.6655 24.6655,23 24.25,23 H 23 v 1 h 1.5 C 25.330998,24 26,23.330998 26,22.5 V 21 Z m -14,2 v 1 h 4 v -1 z m 6,0 v 1 h 4 v -1 z" />
   <g
      id="g4397"
      transform="matrix(1.1201367,0,0,1.1201367,-3.073999,-3.7843059)">

--- a/data/windows.svg
+++ b/data/windows.svg
@@ -1,156 +1,177 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg4715"
-   height="32"
+   version="1.1"
    width="32"
-   version="1.1">
+   height="32"
+   id="svg4715"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4717">
     <linearGradient
-       id="linearGradient3702-501-757-1">
-      <stop
-         id="stop2895-2"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop2897-89"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2899-36"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3688-464-309-7-6">
-      <stop
-         id="stop2889-75"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891-4-9"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(2.003784,0,0,1.4,29.714934,-17.4)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3688-464-309-7-6"
-       id="radialGradient3082-6-3"
-       fy="43.5"
-       fx="4.9929786"
-       r="2.5"
-       cy="43.5"
-       cx="4.9929786" />
-    <radialGradient
-       gradientTransform="matrix(2.003784,0,0,1.4,-18.284598,-104.4)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3688-464-309-7-6"
-       id="radialGradient3084-4-5"
-       fy="43.5"
-       fx="4.9929786"
-       r="2.5"
-       cy="43.5"
-       cx="4.9929786" />
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3702-501-757-1"
-       id="linearGradient3086-8-6"
-       y2="39.999443"
-       x2="25.058096"
-       y1="47.027729"
-       x1="25.058096"
-       gradientTransform="matrix(1.1234054,0,0,1,-2.9617369,0)" />
-    <linearGradient
-       id="linearGradient4632-92-3-0-8-1-6">
-      <stop
-         id="stop4634-68-8-0-2-9-1"
-         style="stop-color:#fafafa;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4636-8-21-7-1-4-9"
-         style="stop-color:#e1e1e1;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.40394,0,0,0.42567,4.5497,-4.793)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4197"
-       y2="57.610001"
-       x2="83.239998"
-       y1="42.457001"
-       x1="83.239998">
-      <stop
-         offset="0"
-         style="stop-color:#e5e5e5;stop-opacity:1"
-         id="stop4199" />
-      <stop
-         offset="1"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         id="stop4201" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.45945947,0,0,0.45945947,0.9742203,8.9717328)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4095"
-       id="linearGradient3233"
-       y2="41.229313"
-       x2="23.99999"
-       y1="8.7674046"
-       x1="23.99999" />
-    <linearGradient
-       id="linearGradient4095">
+       id="linearGradient11">
       <stop
          offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4097" />
+         id="stop8" />
       <stop
-         offset="0"
+         offset="0.04712477"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4100" />
+         id="stop9" />
       <stop
-         offset="1"
+         offset="0.97000003"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4102" />
+         id="stop10" />
       <stop
          offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4104" />
+         id="stop11" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-1">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-2" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-89" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-36" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-1"
+       id="linearGradient3086-8"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3688-464-309-7-6">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-75" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-4-9" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient4632-92-3-0-8-1-6"
-       id="radialGradient3091-8"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.1500005,-1.2044328,-2.1187398e-8,27.17723,-9.8384454)"
-       cx="7.6855783"
-       cy="5.9590135"
-       fx="7.6855783"
-       fy="5.9590135"
-       r="19.99999" />
+       xlink:href="#linearGradient3688-464-309-7-6"
+       id="radialGradient3084-4"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
     <linearGradient
-       y2="17"
-       x2="18"
-       y1="15"
-       x1="18"
-       gradientTransform="translate(3.999999,-11.000027)"
+       id="linearGradient3688-166-749-9">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-2" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-2" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient1072"
-       xlink:href="#linearGradient4197" />
+       xlink:href="#linearGradient3688-166-749-9"
+       id="radialGradient3082-6"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
     <linearGradient
-       y2="41.229313"
-       x2="23.99999"
-       y1="8.7674046"
+       xlink:href="#linearGradient11"
+       id="linearGradient3357"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.51351353,0,0,0.45945948,0.67692102,8.9729767)"
        x1="23.99999"
-       gradientTransform="matrix(0.45945947,0,0,0.45945947,8.9742193,-0.02829385)"
+       y1="6.6617098"
+       x2="23.99999"
+       y2="41.294518" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1512"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient1074"
-       xlink:href="#linearGradient4095" />
+       gradientTransform="matrix(0.51025498,0,0,0.44099646,-15.728038,12.858224)"
+       x1="60.112045"
+       y1="-56.049503"
+       x2="60.112045"
+       y2="-102.48898" />
+    <linearGradient
+       id="linearGradient3600-9-51">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-0-0" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-9-04" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.84787485,0,0,0.94442753,-13.63556,-5.3105166)"
+       x1="23.84874"
+       y1="37.292542"
+       x2="23.84874"
+       y2="16.241379" />
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient14"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.84787485,0,0,0.94442753,-7.6355961,-13.310517)"
+       x1="23.84874"
+       y1="37.292542"
+       x2="23.84874"
+       y2="16.241379" />
+    <linearGradient
+       xlink:href="#linearGradient11"
+       id="linearGradient13"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.51351353,0,0,0.45945948,6.6756723,0.97297677)"
+       x1="23.99999"
+       y1="6.6617098"
+       x2="23.99999"
+       y2="41.294518" />
+    <linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient12"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.51025498,0,0,0.44099646,-9.7280742,20.858288)"
+       x1="60.112045"
+       y1="-56.049503"
+       x2="60.112045"
+       y2="-102.48898" />
   </defs>
   <metadata
      id="metadata4720">
@@ -160,119 +181,121 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     style="opacity:0.35"
-     id="g3712-8-7"
-     transform="matrix(0.5789476,0,0,0.42857134,-1.894738,10.857146)">
-    <rect
-       style="fill:url(#radialGradient3082-6-3);fill-opacity:1;stroke:none"
-       id="rect2801-6-0"
-       y="40"
-       x="39.726803"
-       height="7"
-       width="5" />
-    <rect
-       style="fill:url(#radialGradient3084-4-5);fill-opacity:1;stroke:none"
-       id="rect3696-20-9"
-       transform="scale(-1)"
-       y="-47"
-       x="-8.272728"
-       height="7"
-       width="5" />
-    <rect
-       style="fill:url(#linearGradient3086-8-6);fill-opacity:1;stroke:none"
-       id="rect3700-5-3"
-       y="40"
-       x="8.2723169"
-       height="7.0000005"
-       width="31.455351" />
+     transform="matrix(0.55,0,0,0.3333336,-1.2000011,15.33333)"
+     id="g2036-4"
+     style="display:inline;opacity:0.75">
+    <g
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712-8"
+       style="opacity:0.40000000000000002">
+      <rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801-6"
+         style="fill:url(#radialGradient3082-6);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1,-1)"
+         id="rect3696-20"
+         style="fill:url(#radialGradient3084-4);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700-5"
+         style="fill:url(#linearGradient3086-8);fill-opacity:1;stroke:none" />
+    </g>
   </g>
   <rect
      width="20"
-     height="17"
-     rx="0.5"
-     ry="0.5"
-     x="2"
-     y="12"
-     id="rect5505-21-8"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.23907106;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     id="rect4174"
-     d="m 2.5,11.5 c -0.554,0 -1,0.446 -1,1 V 17 h 21 v -4.5 c 0,-0.554 -0.446,-1 -1,-1 z"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e8e8e8;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.29113925;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <rect
-     width="21"
-     height="18.000027"
-     rx="1"
-     ry="1"
-     x="1.5"
-     y="11.5"
-     id="rect5505-21-8-1-6"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:#0e141f;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     height="18"
+     rx="1.5001274"
+     ry="1.5001274"
+     x="3.0000002"
+     y="-29"
+     transform="scale(1,-1)"
+     id="rect5505"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:url(#linearGradient1512);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1" />
   <rect
      width="19"
-     height="15.998756"
-     x="2.5"
-     y="12.5"
-     id="rect6741-9-0"
-     style="opacity:0.7;fill:none;stroke:url(#linearGradient3233);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-  <path
-     style="opacity:0.15;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="M 2,16.5 H 22"
-     id="path4179" />
+     height="17"
+     x="3.5012493"
+     y="11.5"
+     id="rect6741-9"
+     style="opacity:1;fill:none;stroke:url(#linearGradient3357);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1"
+     ry="1" />
+  <rect
+     width="21.000078"
+     height="19.000078"
+     rx="2"
+     ry="2"
+     x="2.4999981"
+     y="10.499961"
+     id="rect5505-21-8-1"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient7);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1" />
   <rect
      width="24"
      height="21"
-     rx="2"
-     ry="2"
-     x="8"
-     y="2"
-     id="rect5505-21-8-9-6-0"
-     style="color:#000000;font-variation-settings:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.05;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     rx="4"
+     ry="4"
+     x="7.0000005"
+     y="3"
+     id="rect5505-21-8-5-7-5"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.03;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1" />
   <rect
-     width="22"
-     height="19"
-     rx="1"
-     ry="1"
-     x="9"
-     y="3.0000002"
-     id="rect5505-21-8-9-6"
-     style="color:#000000;font-variation-settings:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     width="21.999998"
+     height="20"
+     rx="2.9999998"
+     ry="3"
+     x="8.000001"
+     y="3"
+     id="rect5505-21-8-5-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.07;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
   <rect
      width="20"
-     height="17"
-     rx="0.5"
-     ry="0.5"
-     x="9.999999"
-     y="2.9999733"
-     id="rect5505-21-8-9"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3091-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.23907106;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <path
-     id="rect4174-4"
-     d="m 10.499999,2.4999733 c -0.554,0 -1,0.446 -1,1 v 4.5 h 21 v -4.5 c 0,-0.554 -0.446,-1 -1,-1 z"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1072);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.29113925;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <rect
-     width="21"
-     height="18.000027"
-     rx="1"
-     ry="1"
-     x="9.499999"
-     y="2.4999733"
-     id="rect5505-21-8-1-6-7"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.25;fill:none;stroke:#0e141f;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     height="18"
+     rx="1.5001274"
+     ry="1.5001274"
+     x="8.9999638"
+     y="-20.999935"
+     transform="scale(1,-1)"
+     id="rect5505-2"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient12);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000" />
   <rect
      width="19"
-     height="15.998756"
-     x="10.499999"
-     y="3.4999733"
-     id="rect6741-9-0-8"
-     style="opacity:0.7;fill:none;stroke:url(#linearGradient1074);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     height="17"
+     x="9.5"
+     y="3.5"
+     id="rect6741-9-0"
+     style="fill:none;stroke:url(#linearGradient13);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1.0000001"
+     ry="1" />
+  <rect
+     width="21.000078"
+     height="19.000078"
+     rx="2"
+     ry="2"
+     x="8.4999619"
+     y="2.4999609"
+     id="rect5505-21-8-1-6"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient14);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000" />
   <path
-     style="opacity:0.2;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 9.999999,7.4999733 h 20"
-     id="path4179-4" />
+     id="rect5505-2-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.1;vector-effect:none;fill:#1a1a1a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 10.500001,3 c -0.83107,0 -1.5,0.6689302 -1.5,1.5 v 15 c 0,0.83107 0.66893,1.5 1.5,1.5 h 4.5 V 3 Z" />
+  <path
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;stroke:#0e141f;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none"
+     d="M 14.500001,3 V 21"
+     id="path16" />
 </svg>

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -51,10 +51,10 @@ public class Keyboard.Plug : Switchboard.Plug {
             Gtk.IconTheme.get_for_display (Gdk.Display.get_default ()).add_resource_path ("/io/elementary/settings/keyboard");
 
             stack = new Gtk.Stack ();
+            stack.add_titled (new Keyboard.Behaviour.Page (), "behavior", _("Behavior"));
+            stack.add_titled (new Keyboard.Shortcuts.Page (), "shortcuts", _("Shortcuts"));
             stack.add_titled (new Keyboard.LayoutPage.Page (), "layout", _("Layout"));
             stack.add_titled (new Keyboard.InputMethodPage.Page (), "inputmethod", _("Input Method"));
-            stack.add_titled (new Keyboard.Shortcuts.Page (), "shortcuts", _("Shortcuts"));
-            stack.add_titled (new Keyboard.Behaviour.Page (), "behavior", _("Behavior"));
 
             var stack_switcher = new Gtk.StackSwitcher () {
                 halign = CENTER,

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -51,10 +51,10 @@ public class Keyboard.Plug : Switchboard.Plug {
             Gtk.IconTheme.get_for_display (Gdk.Display.get_default ()).add_resource_path ("/io/elementary/settings/keyboard");
 
             stack = new Gtk.Stack ();
-            stack.add_titled (new Keyboard.Behaviour.Page (), "behavior", _("Behavior"));
-            stack.add_titled (new Keyboard.Shortcuts.Page (), "shortcuts", _("Shortcuts"));
             stack.add_titled (new Keyboard.LayoutPage.Page (), "layout", _("Layout"));
             stack.add_titled (new Keyboard.InputMethodPage.Page (), "inputmethod", _("Input Method"));
+            stack.add_titled (new Keyboard.Shortcuts.Page (), "shortcuts", _("Shortcuts"));
+            stack.add_titled (new Keyboard.Behaviour.Page (), "behavior", _("Behavior"));
 
             var stack_switcher = new Gtk.StackSwitcher () {
                 halign = CENTER,


### PR DESCRIPTION
![Screenshot from 2024-01-23 09 41 14](https://github.com/elementary/switchboard-plug-keyboard/assets/7277719/60f55a76-33e5-4229-b21d-5778c15fd8e3)

* Use latest screenshot icon
* Update windows icon to fit within current tile size and reflect the layout of modern applications