### PR TITLE
Shortcuts: Add "Keyboard Layouts" tab

### DIFF
--- a/src/Shortcuts/Settings.vala
+++ b/src/Shortcuts/Settings.vala
@@ -18,7 +18,7 @@
 */
 
 namespace Keyboard.Shortcuts {
-    private enum Schema { WM, MUTTER, GALA, MEDIA, SOUND_INDICATOR, COUNT }
+    private enum Schema { WM, MUTTER, GALA, MEDIA, SOUND_INDICATOR, IBUS, COUNT }
 
     // helper class for gsettings
     // note that media key are stored as strings, all others as string vectors
@@ -43,6 +43,7 @@ namespace Keyboard.Shortcuts {
                 "org.pantheon.desktop.gala.keybindings",
                 "org.gnome.settings-daemon.plugins.media-keys",
                 "io.elementary.desktop.wingpanel.sound",
+                "org.freedesktop.ibus.panel.emoji"
             };
 
             foreach (var name in schema_names) {

--- a/src/Shortcuts/ShortcutsList.vala
+++ b/src/Shortcuts/ShortcutsList.vala
@@ -35,6 +35,7 @@ namespace Keyboard.Shortcuts {
         public Group media_group;
         public Group a11y_group;
         public Group system_group;
+        public Group keyboard_layouts_group;
         public Group custom_group;
 
         private static GLib.Once<ShortcutsList> instance;
@@ -154,6 +155,14 @@ namespace Keyboard.Shortcuts {
             add_action (ref system_group, Schema.MEDIA, _("Log Out"), "logout");
             add_action (ref system_group, Schema.MUTTER, _("Cycle display mode"), "switch-monitor");
 
+            keyboard_layouts_group = {};
+            keyboard_layouts_group.icon_name = "preferences-desktop-locale";
+            keyboard_layouts_group.label = _("Keyboard Layouts");
+            add_action (ref keyboard_layouts_group, Schema.GALA, _("Switch Keyboard Layout"), "switch-input-source");
+            add_action (ref keyboard_layouts_group, Schema.GALA, _("Switch Keyboard Layout Backwards"), "switch-input-source-backward");
+            add_action (ref keyboard_layouts_group, Schema.IBUS, _("Enable Emoji Typing"), "hotkey");
+            add_action (ref keyboard_layouts_group, Schema.IBUS, _("Enable Unicode Typing"), "unicode-hotkey");
+
             custom_group = {};
             custom_group.icon_name = "applications-other";
             custom_group.label = _("Custom");
@@ -165,7 +174,8 @@ namespace Keyboard.Shortcuts {
                 launchers_group,
                 media_group,
                 a11y_group,
-                system_group
+                system_group,
+                keyboard_layouts_group
             };
         }
 

--- a/src/Views/Shortcuts.vala
+++ b/src/Views/Shortcuts.vala
@@ -29,6 +29,7 @@ namespace Keyboard.Shortcuts {
         MEDIA,
         A11Y,
         SYSTEM,
+        KEYBOARD_LAYOUTS,
         CUSTOM,
         COUNT;
 
@@ -74,6 +75,7 @@ namespace Keyboard.Shortcuts {
             section_switcher.append (new SwitcherRow (list.media_group));
             section_switcher.append (new SwitcherRow (list.a11y_group));
             section_switcher.append (new SwitcherRow (list.system_group));
+            section_switcher.append (new SwitcherRow (list.keyboard_layouts_group));
 
             custom_shortcuts_row = new SwitcherRow (list.custom_group);
             section_switcher.append (custom_shortcuts_row);


### PR DESCRIPTION
![image](https://github.com/elementary/switchboard-plug-keyboard/assets/80143868/2ee00c1e-a96c-47ff-b30e-64cb0efaa55f)

An alternative to https://github.com/elementary/switchboard-plug-keyboard/pull/460 and https://github.com/elementary/default-settings/pull/299

Fixes https://github.com/elementary/switchboard-plug-keyboard/issues/472
Closes https://github.com/elementary/triage/issues/18
