### PR TITLE
Control: add runtime onboard dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,7 @@ Architecture: any
 Depends: gala,
          ibus,
          xkb-data,
+         onboard,
          ${misc:Depends},
          ${shlibs:Depends}
 Enhances: io.elementary.settings


### PR DESCRIPTION
We depend on onboard for on screen keyboard setting so make sure we add it as runtime dep