### PR TITLE
ShortcutsList: use a single list model

### DIFF
--- a/src/Shortcuts/Backend/ConflictsManager.vala
+++ b/src/Shortcuts/Backend/ConflictsManager.vala
@@ -23,19 +23,15 @@ class Keyboard.Shortcuts.ConflictsManager : GLib.Object {
     }
 
     private static bool general_shortcut_conflicts (Shortcut shortcut, out string name, out string group) {
-        unowned var list = ShortcutsList.get_default ();
+        var listmodel = ShortcutsList.get_default ().list_store;
+        for (int i = 0; i < listmodel.n_items; i++) {
+            var shortcut_action = (Keyboard.Shortcuts.Action) listmodel.get_item (i);
 
-        for (int group_id = 0; group_id < SectionID.CUSTOM; group_id++) {
-            var listmodel = list.get_model (group_id);
-            for (int i = 0; i < listmodel.n_items; i++) {
-                var shortcut_action = (Keyboard.Shortcuts.Action) listmodel.get_item (i);
+            var action_shortcut = Settings.get_default ().get_val (shortcut_action.schema, shortcut_action.key);
 
-                var action_shortcut = Settings.get_default ().get_val (shortcut_action.schema, shortcut_action.key);
-
-                if (shortcut.is_equal (action_shortcut)) {
-                    name = shortcut_action.action;
-                    return true;
-                }
+            if (shortcut.is_equal (action_shortcut)) {
+                name = shortcut_action.action;
+                return true;
             }
         }
 

--- a/src/Shortcuts/Backend/ShortcutsList.vala
+++ b/src/Shortcuts/Backend/ShortcutsList.vala
@@ -18,20 +18,20 @@
 */
 
 namespace Keyboard.Shortcuts {
-    struct Group {
+    public struct Group {
         public string icon_name;
         public string label;
-
-        public GLib.ListStore list;
     }
 
     public class Action : Object {
+        public SectionID section_id { get; construct; }
         public Schema schema { get; construct; }
         public string action { get; construct; }
         public string key { get; construct; }
 
-        public Action (Schema schema, string action, string key) {
+        public Action (SectionID section_id, Schema schema, string action, string key) {
             Object (
+                section_id: section_id,
                 schema: schema,
                 action: action,
                 key: key
@@ -51,6 +51,8 @@ namespace Keyboard.Shortcuts {
         public Group keyboard_layouts_group;
         public Group custom_group;
 
+        public ListStore list_store { get; private set; }
+
         private static GLib.Once<ShortcutsList> instance;
         public static unowned ShortcutsList get_default () {
             return instance.once (() => {
@@ -61,149 +63,133 @@ namespace Keyboard.Shortcuts {
         private ShortcutsList () {}
 
         construct {
-            windows_group = Group () {
-                list = new GLib.ListStore (typeof (Keyboard.Shortcuts.Action))
-            };
+            list_store = new GLib.ListStore (typeof (Keyboard.Shortcuts.Action));
+
+            windows_group = Group ();
             windows_group.icon_name = "io.elementary.settings.keyboard.windows";
             windows_group.label = _("Windows");
-            add_action (ref windows_group, Schema.WM, _("Close"), "close");
-            add_action (ref windows_group, Schema.WM, _("Lower"), "lower");
-            add_action (ref windows_group, Schema.WM, _("Maximize"), "maximize");
-            add_action (ref windows_group, Schema.WM, _("Unmaximize"), "unmaximize");
-            add_action (ref windows_group, Schema.WM, _("Toggle Maximized"), "toggle-maximized");
-            add_action (ref windows_group, Schema.WM, _("Hide"), "minimize");
-            add_action (ref windows_group, Schema.WM, _("Toggle Fullscreen"), "toggle-fullscreen");
-            add_action (ref windows_group, Schema.WM, _("Toggle on all Workspaces"), "toggle-on-all-workspaces");
-            add_action (ref windows_group, Schema.WM, _("Toggle always on Top"), "toggle-above");
-            add_action (ref windows_group, Schema.WM, _("Cycle Windows"), "switch-windows");
-            add_action (ref windows_group, Schema.WM, _("Cycle Windows backwards"), "switch-windows-backward");
-            add_action (ref windows_group, Schema.WM, _("Cycle Windows of application"), "switch-group");
-            add_action (ref windows_group, Schema.WM, _("Cycle Windows of application backwards"), "switch-group-backward");
-            add_action (ref windows_group, Schema.MUTTER, _("Tile Left"), "toggle-tiled-left");
-            add_action (ref windows_group, Schema.MUTTER, _("Tile Right"), "toggle-tiled-right");
-            add_action (ref windows_group, Schema.GALA, _("Window Overview"), "expose-windows");
-            add_action (ref windows_group, Schema.GALA, _("Show All Windows"), "expose-all-windows");
-            add_action (ref windows_group, Schema.GALA, _("Picture in Picture Mode"), "pip");
-            add_action (ref windows_group, Schema.WM, _("Move to display above"), "move-to-monitor-up");
-            add_action (ref windows_group, Schema.WM, _("Move to display below"), "move-to-monitor-down");
-            add_action (ref windows_group, Schema.WM, _("Move to right display"), "move-to-monitor-right");
-            add_action (ref windows_group, Schema.WM, _("Move to left display"), "move-to-monitor-left");
+            add_action (SectionID.WINDOWS, Schema.WM, _("Close"), "close");
+            add_action (SectionID.WINDOWS, Schema.WM, _("Lower"), "lower");
+            add_action (SectionID.WINDOWS, Schema.WM, _("Maximize"), "maximize");
+            add_action (SectionID.WINDOWS, Schema.WM, _("Unmaximize"), "unmaximize");
+            add_action (SectionID.WINDOWS, Schema.WM, _("Toggle Maximized"), "toggle-maximized");
+            add_action (SectionID.WINDOWS, Schema.WM, _("Hide"), "minimize");
+            add_action (SectionID.WINDOWS, Schema.WM, _("Toggle Fullscreen"), "toggle-fullscreen");
+            add_action (SectionID.WINDOWS, Schema.WM, _("Toggle on all Workspaces"), "toggle-on-all-workspaces");
+            add_action (SectionID.WINDOWS, Schema.WM, _("Toggle always on Top"), "toggle-above");
+            add_action (SectionID.WINDOWS, Schema.WM, _("Cycle Windows"), "switch-windows");
+            add_action (SectionID.WINDOWS, Schema.WM, _("Cycle Windows backwards"), "switch-windows-backward");
+            add_action (SectionID.WINDOWS, Schema.WM, _("Cycle Windows of application"), "switch-group");
+            add_action (SectionID.WINDOWS, Schema.WM, _("Cycle Windows of application backwards"), "switch-group-backward");
+            add_action (SectionID.WINDOWS, Schema.MUTTER, _("Tile Left"), "toggle-tiled-left");
+            add_action (SectionID.WINDOWS, Schema.MUTTER, _("Tile Right"), "toggle-tiled-right");
+            add_action (SectionID.WINDOWS, Schema.GALA, _("Window Overview"), "expose-windows");
+            add_action (SectionID.WINDOWS, Schema.GALA, _("Show All Windows"), "expose-all-windows");
+            add_action (SectionID.WINDOWS, Schema.GALA, _("Picture in Picture Mode"), "pip");
+            add_action (SectionID.WINDOWS, Schema.WM, _("Move to display above"), "move-to-monitor-up");
+            add_action (SectionID.WINDOWS, Schema.WM, _("Move to display below"), "move-to-monitor-down");
+            add_action (SectionID.WINDOWS, Schema.WM, _("Move to right display"), "move-to-monitor-right");
+            add_action (SectionID.WINDOWS, Schema.WM, _("Move to left display"), "move-to-monitor-left");
 
-            workspaces_group = Group () {
-                list = new GLib.ListStore (typeof (Keyboard.Shortcuts.Action))
-            };
+            workspaces_group = Group ();
             workspaces_group.icon_name = "preferences-desktop-workspaces";
             workspaces_group.label = _("Workspaces");
-            add_action (ref workspaces_group, Schema.GALA, _("Multitasking View"), "toggle-multitasking-view");
-            add_action (ref workspaces_group, Schema.WM, _("Switch left"), "switch-to-workspace-left");
-            add_action (ref workspaces_group, Schema.WM, _("Switch right"), "switch-to-workspace-right");
-            add_action (ref workspaces_group, Schema.GALA, _("Switch to first"), "switch-to-workspace-first");
-            add_action (ref workspaces_group, Schema.GALA, _("Switch to new"), "switch-to-workspace-last");
-            add_action (ref workspaces_group, Schema.WM, _("Switch to workspace 1"), "switch-to-workspace-1");
-            add_action (ref workspaces_group, Schema.WM, _("Switch to workspace 2"), "switch-to-workspace-2");
-            add_action (ref workspaces_group, Schema.WM, _("Switch to workspace 3"), "switch-to-workspace-3");
-            add_action (ref workspaces_group, Schema.WM, _("Switch to workspace 4"), "switch-to-workspace-4");
-            add_action (ref workspaces_group, Schema.WM, _("Switch to workspace 5"), "switch-to-workspace-5");
-            add_action (ref workspaces_group, Schema.WM, _("Switch to workspace 6"), "switch-to-workspace-6");
-            add_action (ref workspaces_group, Schema.WM, _("Switch to workspace 7"), "switch-to-workspace-7");
-            add_action (ref workspaces_group, Schema.WM, _("Switch to workspace 8"), "switch-to-workspace-8");
-            add_action (ref workspaces_group, Schema.WM, _("Switch to workspace 9"), "switch-to-workspace-9");
-            add_action (ref workspaces_group, Schema.GALA, _("Cycle workspaces"), "cycle-workspaces-next");
-            add_action (ref workspaces_group, Schema.GALA, _("Cycle workspaces backwards"), "cycle-workspaces-previous");
-            add_action (ref workspaces_group, Schema.WM, _("Move to workspace 1"), "move-to-workspace-1");
-            add_action (ref workspaces_group, Schema.WM, _("Move to workspace 2"), "move-to-workspace-2");
-            add_action (ref workspaces_group, Schema.WM, _("Move to workspace 3"), "move-to-workspace-3");
-            add_action (ref workspaces_group, Schema.WM, _("Move to workspace 4"), "move-to-workspace-4");
-            add_action (ref workspaces_group, Schema.WM, _("Move to workspace 5"), "move-to-workspace-5");
-            add_action (ref workspaces_group, Schema.WM, _("Move to workspace 6"), "move-to-workspace-6");
-            add_action (ref workspaces_group, Schema.WM, _("Move to workspace 7"), "move-to-workspace-7");
-            add_action (ref workspaces_group, Schema.WM, _("Move to workspace 8"), "move-to-workspace-8");
-            add_action (ref workspaces_group, Schema.WM, _("Move to workspace 9"), "move-to-workspace-9");
-            add_action (ref workspaces_group, Schema.WM, _("Move to left workspace"), "move-to-workspace-left");
-            add_action (ref workspaces_group, Schema.WM, _("Move to right workspace"), "move-to-workspace-right");
+            add_action (SectionID.WORKSPACES, Schema.GALA, _("Multitasking View"), "toggle-multitasking-view");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Switch left"), "switch-to-workspace-left");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Switch right"), "switch-to-workspace-right");
+            add_action (SectionID.WORKSPACES, Schema.GALA, _("Switch to first"), "switch-to-workspace-first");
+            add_action (SectionID.WORKSPACES, Schema.GALA, _("Switch to new"), "switch-to-workspace-last");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Switch to workspace 1"), "switch-to-workspace-1");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Switch to workspace 2"), "switch-to-workspace-2");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Switch to workspace 3"), "switch-to-workspace-3");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Switch to workspace 4"), "switch-to-workspace-4");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Switch to workspace 5"), "switch-to-workspace-5");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Switch to workspace 6"), "switch-to-workspace-6");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Switch to workspace 7"), "switch-to-workspace-7");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Switch to workspace 8"), "switch-to-workspace-8");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Switch to workspace 9"), "switch-to-workspace-9");
+            add_action (SectionID.WORKSPACES, Schema.GALA, _("Cycle workspaces"), "cycle-workspaces-next");
+            add_action (SectionID.WORKSPACES, Schema.GALA, _("Cycle workspaces backwards"), "cycle-workspaces-previous");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Move to workspace 1"), "move-to-workspace-1");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Move to workspace 2"), "move-to-workspace-2");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Move to workspace 3"), "move-to-workspace-3");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Move to workspace 4"), "move-to-workspace-4");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Move to workspace 5"), "move-to-workspace-5");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Move to workspace 6"), "move-to-workspace-6");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Move to workspace 7"), "move-to-workspace-7");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Move to workspace 8"), "move-to-workspace-8");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Move to workspace 9"), "move-to-workspace-9");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Move to left workspace"), "move-to-workspace-left");
+            add_action (SectionID.WORKSPACES, Schema.WM, _("Move to right workspace"), "move-to-workspace-right");
 
-            screenshot_group = Group () {
-                list = new GLib.ListStore (typeof (Keyboard.Shortcuts.Action))
-            };
+            screenshot_group = Group ();
             screenshot_group.icon_name = "accessories-screenshot-tool";
             screenshot_group.label = _("Screenshots");
-            add_action (ref screenshot_group, Schema.GALA, _("Grab the whole screen"), "screenshot");
-            add_action (ref screenshot_group, Schema.GALA, _("Copy the whole screen to clipboard"), "screenshot-clip");
-            add_action (ref screenshot_group, Schema.GALA, _("Grab the current window"), "window-screenshot");
-            add_action (ref screenshot_group, Schema.GALA, _("Copy the current window to clipboard"), "window-screenshot-clip");
-            add_action (ref screenshot_group, Schema.GALA, _("Select an area to grab"), "area-screenshot");
-            add_action (ref screenshot_group, Schema.GALA, _("Copy an area to clipboard"), "area-screenshot-clip");
+            add_action (SectionID.SCREENSHOTS, Schema.GALA, _("Grab the whole screen"), "screenshot");
+            add_action (SectionID.SCREENSHOTS, Schema.GALA, _("Copy the whole screen to clipboard"), "screenshot-clip");
+            add_action (SectionID.SCREENSHOTS, Schema.GALA, _("Grab the current window"), "window-screenshot");
+            add_action (SectionID.SCREENSHOTS, Schema.GALA, _("Copy the current window to clipboard"), "window-screenshot-clip");
+            add_action (SectionID.SCREENSHOTS, Schema.GALA, _("Select an area to grab"), "area-screenshot");
+            add_action (SectionID.SCREENSHOTS, Schema.GALA, _("Copy an area to clipboard"), "area-screenshot-clip");
 
-            launchers_group = Group () {
-                list = new GLib.ListStore (typeof (Keyboard.Shortcuts.Action))
-            };
+            launchers_group = Group ();
             launchers_group.icon_name = "io.elementary.settings.keyboard.applications";
             launchers_group.label = _("Applications");
-            add_action (ref launchers_group, Schema.MEDIA, _("Email"), "email");
-            add_action (ref launchers_group, Schema.MEDIA, _("Home Folder"), "home");
-            add_action (ref launchers_group, Schema.MEDIA, _("Music"), "media");
-            add_action (ref launchers_group, Schema.MEDIA, _("Terminal"), "terminal");
-            add_action (ref launchers_group, Schema.MEDIA, _("Internet Browser"), "www");
-            add_action (ref launchers_group, Schema.DOCK, _("Launch first dock item"), "launch-dock-1");
-            add_action (ref launchers_group, Schema.DOCK, _("Launch second dock item"), "launch-dock-2");
-            add_action (ref launchers_group, Schema.DOCK, _("Launch third dock item"), "launch-dock-3");
-            add_action (ref launchers_group, Schema.DOCK, _("Launch fourth dock item"), "launch-dock-4");
-            add_action (ref launchers_group, Schema.DOCK, _("Launch fifth dock item"), "launch-dock-5");
-            add_action (ref launchers_group, Schema.DOCK, _("Launch sixth dock item"), "launch-dock-6");
-            add_action (ref launchers_group, Schema.DOCK, _("Launch seventh dock item"), "launch-dock-7");
-            add_action (ref launchers_group, Schema.DOCK, _("Launch eighth dock item"), "launch-dock-8");
-            add_action (ref launchers_group, Schema.DOCK, _("Launch ninth dock item"), "launch-dock-9");
+            add_action (SectionID.APPS, Schema.MEDIA, _("Email"), "email");
+            add_action (SectionID.APPS, Schema.MEDIA, _("Home Folder"), "home");
+            add_action (SectionID.APPS, Schema.MEDIA, _("Music"), "media");
+            add_action (SectionID.APPS, Schema.MEDIA, _("Terminal"), "terminal");
+            add_action (SectionID.APPS, Schema.MEDIA, _("Internet Browser"), "www");
+            add_action (SectionID.APPS, Schema.DOCK, _("Launch first dock item"), "launch-dock-1");
+            add_action (SectionID.APPS, Schema.DOCK, _("Launch second dock item"), "launch-dock-2");
+            add_action (SectionID.APPS, Schema.DOCK, _("Launch third dock item"), "launch-dock-3");
+            add_action (SectionID.APPS, Schema.DOCK, _("Launch fourth dock item"), "launch-dock-4");
+            add_action (SectionID.APPS, Schema.DOCK, _("Launch fifth dock item"), "launch-dock-5");
+            add_action (SectionID.APPS, Schema.DOCK, _("Launch sixth dock item"), "launch-dock-6");
+            add_action (SectionID.APPS, Schema.DOCK, _("Launch seventh dock item"), "launch-dock-7");
+            add_action (SectionID.APPS, Schema.DOCK, _("Launch eighth dock item"), "launch-dock-8");
+            add_action (SectionID.APPS, Schema.DOCK, _("Launch ninth dock item"), "launch-dock-9");
 
-            media_group = Group () {
-                list = new GLib.ListStore (typeof (Keyboard.Shortcuts.Action))
-            };
+            media_group = Group ();
             media_group.icon_name = "applications-multimedia";
             media_group.label = _("Media");
-            add_action (ref media_group, Schema.SOUND_INDICATOR, _("Volume Up"), "volume-up");
-            add_action (ref media_group, Schema.SOUND_INDICATOR, _("Volume Down"), "volume-down");
-            add_action (ref media_group, Schema.SOUND_INDICATOR, _("Mute"), "volume-mute");
-            add_action (ref media_group, Schema.MEDIA, _("Play/Pause"), "play");
-            add_action (ref media_group, Schema.MEDIA, _("Pause"), "pause");
-            add_action (ref media_group, Schema.MEDIA, _("Stop"), "stop");
-            add_action (ref media_group, Schema.MEDIA, _("Previous Track"), "previous");
-            add_action (ref media_group, Schema.MEDIA, _("Next Track"), "next");
-            add_action (ref media_group, Schema.MEDIA, _("Eject"), "eject");
+            add_action (SectionID.MEDIA, Schema.SOUND_INDICATOR, _("Volume Up"), "volume-up");
+            add_action (SectionID.MEDIA, Schema.SOUND_INDICATOR, _("Volume Down"), "volume-down");
+            add_action (SectionID.MEDIA, Schema.SOUND_INDICATOR, _("Mute"), "volume-mute");
+            add_action (SectionID.MEDIA, Schema.MEDIA, _("Play/Pause"), "play");
+            add_action (SectionID.MEDIA, Schema.MEDIA, _("Pause"), "pause");
+            add_action (SectionID.MEDIA, Schema.MEDIA, _("Stop"), "stop");
+            add_action (SectionID.MEDIA, Schema.MEDIA, _("Previous Track"), "previous");
+            add_action (SectionID.MEDIA, Schema.MEDIA, _("Next Track"), "next");
+            add_action (SectionID.MEDIA, Schema.MEDIA, _("Eject"), "eject");
 
-            a11y_group = Group () {
-                list = new GLib.ListStore (typeof (Keyboard.Shortcuts.Action))
-            };
+            a11y_group = Group ();
             a11y_group.icon_name = "preferences-desktop-accessibility";
             a11y_group.label = _("Universal Access");
-            add_action (ref a11y_group, Schema.MEDIA, _("Decrease Text Size"), "decrease-text-size");
-            add_action (ref a11y_group, Schema.MEDIA, _("Increase Text Size"), "increase-text-size");
-            add_action (ref a11y_group, Schema.GALA, _("Magnifier Zoom in"), "zoom-in");
-            add_action (ref a11y_group, Schema.GALA, _("Magnifier Zoom out"), "zoom-out");
-            add_action (ref a11y_group, Schema.MEDIA, _("Toggle On Screen Keyboard"), "on-screen-keyboard");
-            add_action (ref a11y_group, Schema.MEDIA, _("Toggle Screenreader"), "screenreader");
+            add_action (SectionID.A11Y, Schema.MEDIA, _("Decrease Text Size"), "decrease-text-size");
+            add_action (SectionID.A11Y, Schema.MEDIA, _("Increase Text Size"), "increase-text-size");
+            add_action (SectionID.A11Y, Schema.GALA, _("Magnifier Zoom in"), "zoom-in");
+            add_action (SectionID.A11Y, Schema.GALA, _("Magnifier Zoom out"), "zoom-out");
+            add_action (SectionID.A11Y, Schema.MEDIA, _("Toggle On Screen Keyboard"), "on-screen-keyboard");
+            add_action (SectionID.A11Y, Schema.MEDIA, _("Toggle Screenreader"), "screenreader");
 
-            system_group = Group () {
-                list = new GLib.ListStore (typeof (Keyboard.Shortcuts.Action))
-            };
+            system_group = Group ();
             system_group.icon_name = "preferences-system";
             system_group.label = _("System");
-            add_action (ref system_group, Schema.GALA, _("Applications Menu"), "panel-main-menu");
-            add_action (ref system_group, Schema.MEDIA, _("Lock"), "screensaver");
-            add_action (ref system_group, Schema.MEDIA, _("Log Out"), "logout");
-            add_action (ref system_group, Schema.MUTTER, _("Cycle display mode"), "switch-monitor");
+            add_action (SectionID.SYSTEM, Schema.GALA, _("Applications Menu"), "panel-main-menu");
+            add_action (SectionID.SYSTEM, Schema.MEDIA, _("Lock"), "screensaver");
+            add_action (SectionID.SYSTEM, Schema.MEDIA, _("Log Out"), "logout");
+            add_action (SectionID.SYSTEM, Schema.MUTTER, _("Cycle display mode"), "switch-monitor");
 
-            keyboard_layouts_group = Group () {
-                list = new GLib.ListStore (typeof (Keyboard.Shortcuts.Action))
-            };
+            keyboard_layouts_group = Group ();
             keyboard_layouts_group.icon_name = "preferences-desktop-locale";
             keyboard_layouts_group.label = _("Keyboard Layouts");
-            add_action (ref keyboard_layouts_group, Schema.GALA, _("Switch Keyboard Layout"), "switch-input-source");
-            add_action (ref keyboard_layouts_group, Schema.GALA, _("Switch Keyboard Layout Backwards"), "switch-input-source-backward");
-            add_action (ref keyboard_layouts_group, Schema.IBUS, _("Enable Emoji Typing"), "hotkey");
-            add_action (ref keyboard_layouts_group, Schema.IBUS, _("Enable Unicode Typing"), "unicode-hotkey");
+            add_action (SectionID.KEYBOARD_LAYOUTS, Schema.GALA, _("Switch Keyboard Layout"), "switch-input-source");
+            add_action (SectionID.KEYBOARD_LAYOUTS, Schema.GALA, _("Switch Keyboard Layout Backwards"), "switch-input-source-backward");
+            add_action (SectionID.KEYBOARD_LAYOUTS, Schema.IBUS, _("Enable Emoji Typing"), "hotkey");
+            add_action (SectionID.KEYBOARD_LAYOUTS, Schema.IBUS, _("Enable Unicode Typing"), "unicode-hotkey");
 
-            custom_group = Group () {
-                list = new GLib.ListStore (typeof (Keyboard.Shortcuts.Action))
-            };
+            custom_group = Group ();
             custom_group.icon_name = "applications-other";
             custom_group.label = _("Custom");
 
@@ -219,15 +205,11 @@ namespace Keyboard.Shortcuts {
             };
         }
 
-        public ListStore get_model (SectionID group) {
-            return groups[group].list;
-        }
-
-        public void add_action (ref Group group, Schema schema, string action, string key) {
-            var action_object = new Keyboard.Shortcuts.Action (schema, action, key);
+        public void add_action (SectionID section_id, Schema schema, string action, string key) {
+            var action_object = new Keyboard.Shortcuts.Action (section_id, schema, action, key);
 
             if (Settings.get_default ().valid (schema, key)) {
-                group.list.append (action_object);
+                list_store.append (action_object);
             }
         }
     }

--- a/src/Shortcuts/Backend/ShortcutsList.vala
+++ b/src/Shortcuts/Backend/ShortcutsList.vala
@@ -18,7 +18,7 @@
 */
 
 namespace Keyboard.Shortcuts {
-    public struct Group {
+    struct Group {
         public string icon_name;
         public string label;
     }

--- a/src/Shortcuts/Backend/ShortcutsList.vala
+++ b/src/Shortcuts/Backend/ShortcutsList.vala
@@ -40,7 +40,6 @@ namespace Keyboard.Shortcuts {
     }
 
     class ShortcutsList : GLib.Object {
-        public Group[] groups;
         public Group windows_group;
         public Group workspaces_group;
         public Group screenshot_group;
@@ -192,17 +191,6 @@ namespace Keyboard.Shortcuts {
             custom_group = Group ();
             custom_group.icon_name = "applications-other";
             custom_group.label = _("Custom");
-
-            groups = {
-                windows_group,
-                workspaces_group,
-                screenshot_group,
-                launchers_group,
-                media_group,
-                a11y_group,
-                system_group,
-                keyboard_layouts_group
-            };
         }
 
         public void add_action (SectionID section_id, Schema schema, string action, string key) {

--- a/src/Shortcuts/Widgets/ShortcutListBox.vala
+++ b/src/Shortcuts/Widgets/ShortcutListBox.vala
@@ -27,11 +27,18 @@ private class Keyboard.Shortcuts.ShortcutListBox : Gtk.Box {
     construct {
         var sizegroup = new Gtk.SizeGroup (VERTICAL);
 
+        var filter_model = new Gtk.FilterListModel (ShortcutsList.get_default ().list_store, new Gtk.CustomFilter ((obj) => {
+            var action_object = (Keyboard.Shortcuts.Action) obj;
+            return action_object.section_id == group;
+        })) {
+            incremental = true
+        };
+
         var list_box = new Gtk.ListBox () {
             hexpand = true
         };
         list_box.bind_model (
-            ShortcutsList.get_default ().get_model (group),
+            filter_model,
             (object) => {
                 var action_object = (Keyboard.Shortcuts.Action) object;
 


### PR DESCRIPTION
Part of a long-term evil plan to allow searching shortcuts. Instead of creating separate list models for each shortcut section, add `SectionID` to Action objects and filter. 

In a future branch, I'll replace the separate listboxes with a single listbox and we can update the filter when sidebar sections are selected